### PR TITLE
Retries and configure private

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ develop-eggs
 .venv
 .coverage
 cover
+.stestr
 
 # Others
 .*.swp

--- a/networking_generic_switch/devices/netmiko_devices/__init__.py
+++ b/networking_generic_switch/devices/netmiko_devices/__init__.py
@@ -14,7 +14,6 @@
 
 import atexit
 import contextlib
-import time
 import uuid
 
 import netmiko
@@ -24,12 +23,9 @@ import paramiko
 import tenacity
 from tooz import coordination
 
-from netmiko.py23_compat import string_types
-
 from networking_generic_switch import devices
 from networking_generic_switch import exceptions as exc
 from networking_generic_switch import locking as ngs_lock
-
 
 LOG = logging.getLogger(__name__)
 CONF = cfg.CONF
@@ -143,7 +139,6 @@ class NetmikoSwitch(devices.GenericSwitchDevice):
             with ngs_lock.PoolLock(self.locker, **self.lock_kwargs):
                 with self._get_connection() as net_connect:
                     net_connect.enable()
-
                     output = self.send_config_set(
                          net_connect, config_commands=cmd_set)
                     # NOTE (vsaienko) always save configuration

--- a/networking_generic_switch/devices/netmiko_devices/__init__.py
+++ b/networking_generic_switch/devices/netmiko_devices/__init__.py
@@ -140,7 +140,7 @@ class NetmikoSwitch(devices.GenericSwitchDevice):
                 with self._get_connection() as net_connect:
                     net_connect.enable()
                     output = self.send_config_set(
-                         net_connect, config_commands=cmd_set)
+                        net_connect, config_commands=cmd_set)
                     # NOTE (vsaienko) always save configuration
                     # when configuration is applied successfully.
                     self.save_configuration(net_connect)

--- a/networking_generic_switch/devices/netmiko_devices/juniper.py
+++ b/networking_generic_switch/devices/netmiko_devices/juniper.py
@@ -13,6 +13,8 @@
 #    under the License.
 import time
 
+import tenacity
+
 from netmiko.py23_compat import string_types
 
 from networking_generic_switch.devices import netmiko_devices
@@ -52,6 +54,8 @@ class Juniper(netmiko_devices.NetmikoSwitch):
         'vlan members {segmentation_id}',
     )
 
+    @tenacity.retry(reraise=True, stop=tenacity.stop_after_attempt(3),
+                    wait=tenacity.wait_fixed(14))
     def send_config_set(self, net_connect, config_commands=None,
                         exit_config_mode=True, delay_factor=1, max_loops=150,
                         strip_prompt=False, strip_command=False,

--- a/networking_generic_switch/devices/netmiko_devices/juniper.py
+++ b/networking_generic_switch/devices/netmiko_devices/juniper.py
@@ -11,6 +11,9 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+import time
+
+from netmiko.py23_compat import string_types
 
 from networking_generic_switch.devices import netmiko_devices
 
@@ -48,6 +51,42 @@ class Juniper(netmiko_devices.NetmikoSwitch):
         'delete interface {port} unit 0 family ethernet-switching '
         'vlan members {segmentation_id}',
     )
+
+    def send_config_set(self, net_connect, config_commands=None,
+                        exit_config_mode=True, delay_factor=1, max_loops=150,
+                        strip_prompt=False, strip_command=False,
+                        config_mode_cmd='configure private'):
+        """Temporarily overriding the send_config_set method from netmiko.
+
+        Temporarily overriding the send_config_set method from netmiko, until
+        upstream patch is accepted:
+
+        https://github.com/ktbyers/netmiko/pull/593
+
+        """
+
+        delay_factor = net_connect.select_delay_factor(delay_factor)
+        if config_commands is None:
+            return ''
+        elif isinstance(config_commands, string_types):
+            config_commands = (config_commands,)
+
+        if not hasattr(config_commands, '__iter__'):
+            raise ValueError("Invalid argument passed into send_config_set")
+
+        # Send config commands
+        output = net_connect.config_mode(config_mode_cmd)
+        for cmd in config_commands:
+            net_connect.write_channel(net_connect.normalize_cmd(cmd))
+            time.sleep(delay_factor * .5)
+
+        # Gather output
+        output += net_connect._read_channel_timing(
+            delay_factor=delay_factor, max_loops=max_loops)
+        if exit_config_mode:
+            output += net_connect.exit_config_mode()
+        output = net_connect._sanitize_output(output)
+        return output
 
     def save_configuration(self, net_connect):
         """Save the device's configuration.

--- a/networking_generic_switch/tests/unit/netmiko/test_juniper.py
+++ b/networking_generic_switch/tests/unit/netmiko/test_juniper.py
@@ -51,7 +51,8 @@ class TestNetmikoJuniper(test_netmiko_base.NetmikoSwitchTestBase):
                 'NetmikoSwitch.send_commands_to_device')
     def test_del_network(self, mock_exec):
         self.switch.del_network(33, '0ae071f55be943e480eae41fefe85b21')
-        mock_exec.assert_called_with(['delete vlans 0ae071f55be943e480eae41fefe85b21'])
+        mock_exec.assert_called_with([
+            'delete vlans 0ae071f55be943e480eae41fefe85b21'])
 
     @mock.patch('networking_generic_switch.devices.netmiko_devices.'
                 'NetmikoSwitch.send_commands_to_device')

--- a/networking_generic_switch/tests/unit/netmiko/test_netmiko_base.py
+++ b/networking_generic_switch/tests/unit/netmiko/test_netmiko_base.py
@@ -185,6 +185,7 @@ class TestNetmikoSwitch(NetmikoSwitchTestBase):
         connect_mock = mock.MagicMock(SAVE_CONFIGURATION=None)
         connect_mock.__enter__.return_value = connect_mock
         nm_mock.return_value = connect_mock
+
         lock_mock.return_value.__enter__.return_value = lock_mock
         switch.send_commands_to_device(['spam ham'])
 

--- a/networking_generic_switch/tests/unit/netmiko/test_netmiko_base.py
+++ b/networking_generic_switch/tests/unit/netmiko/test_netmiko_base.py
@@ -185,7 +185,6 @@ class TestNetmikoSwitch(NetmikoSwitchTestBase):
         connect_mock = mock.MagicMock(SAVE_CONFIGURATION=None)
         connect_mock.__enter__.return_value = connect_mock
         nm_mock.return_value = connect_mock
-
         lock_mock.return_value.__enter__.return_value = lock_mock
         switch.send_commands_to_device(['spam ham'])
 


### PR DESCRIPTION
Added "config_mode_cmd='configure private'" to the send_config_set command for use with juniper switches.

Unfortunatley, this has to include a temporary hack to allow the config mode to be set to "configure private", because there is an `output = self.config_mode()` in `send_config_set`. This will override any external call to config_mode which is required to set it to 'configure private'. The real fix is needed upstream in the netmiko codebase, but until such time as that PR is accepted, this hack is necessary.   