### PR TITLE
Add physical network awareness

### DIFF
--- a/networking_generic_switch/devices/__init__.py
+++ b/networking_generic_switch/devices/__init__.py
@@ -28,6 +28,8 @@ NGS_INTERNAL_OPTS = [
     {'name': 'ngs_mac_address'},
     # Comma-separated list of names of interfaces to be added to each network.
     {'name': 'ngs_trunk_ports'},
+    # Comma-separated list of physical networks to which this switch is mapped.
+    {'name': 'ngs_physical_networks'},
     {'name': 'ngs_ssh_connect_timeout', 'default': 60},
     {'name': 'ngs_ssh_connect_interval', 'default': 10},
     {'name': 'ngs_max_connections', 'default': 1},
@@ -81,6 +83,13 @@ class GenericSwitchDevice(object):
         if not trunk_ports:
             return []
         return trunk_ports.split(',')
+
+    def _get_physical_networks(self):
+        """Return a list of physical networks mapped to this switch."""
+        physnets = self.ngs_config.get('ngs_physical_networks')
+        if not physnets:
+            return []
+        return physnets.split(',')
 
     @abc.abstractmethod
     def add_network(self, segmentation_id, network_id):

--- a/networking_generic_switch/tests/unit/test_devices.py
+++ b/networking_generic_switch/tests/unit/test_devices.py
@@ -88,18 +88,22 @@ class TestDeviceManager(unittest.TestCase):
                       "ngs_mac_address": 'aa:bb:cc:dd:ee:ff',
                       "ngs_ssh_connect_timeout": "120",
                       "ngs_ssh_connect_interval": "20",
-                      "ngs_trunk_ports": "port1,port2"}
+                      "ngs_trunk_ports": "port1,port2",
+                      "ngs_physical_networks": "physnet1,physnet2"}
         device = devices.device_manager(device_cfg)
         self.assertIsInstance(device, devices.GenericSwitchDevice)
         self.assertNotIn('ngs_mac_address', device.config)
         self.assertNotIn('ngs_ssh_connect_timeout', device.config)
         self.assertNotIn('ngs_ssh_connect_interval', device.config)
         self.assertNotIn('ngs_trunk_ports', device.config)
+        self.assertNotIn('ngs_physical_networks', device.config)
         self.assertEqual('aa:bb:cc:dd:ee:ff',
                          device.ngs_config['ngs_mac_address'])
         self.assertEqual('120', device.ngs_config['ngs_ssh_connect_timeout'])
         self.assertEqual('20', device.ngs_config['ngs_ssh_connect_interval'])
         self.assertEqual('port1,port2', device.ngs_config['ngs_trunk_ports'])
+        self.assertEqual('physnet1,physnet2',
+                         device.ngs_config['ngs_physical_networks'])
 
     def test_driver_ngs_config_defaults(self):
         device_cfg = {"device_type": 'netmiko_ovs_linux'}
@@ -109,3 +113,4 @@ class TestDeviceManager(unittest.TestCase):
         self.assertEqual(60, device.ngs_config['ngs_ssh_connect_timeout'])
         self.assertEqual(10, device.ngs_config['ngs_ssh_connect_interval'])
         self.assertNotIn('ngs_trunk_ports', device.ngs_config)
+        self.assertNotIn('ngs_physical_networks', device.ngs_config)


### PR DESCRIPTION
Ironic added support for physical network awareness [1] in the pike
release. With multiple physical networks it is possible that each
physical network extends over a subset of the devices in a network.
Further, the segmentation ID space on different physical networks may
overlap.

This change adds support for configuration of a set of physical networks
on each switch. On neutron network creation and deletion, NGS will only
(de)provision VLANs on devices tagged with that network's physical
network. If a device is not tagged with any physical networks, the old
behaviour of provisioning all networks on all devices is used.

Configuration of physical networks is be via a new per-device config
option, ngs_physical_networks:

[genericswitch:switch1]
device_type = acme
ip = 1.2.3.4
username = bob
password = drowssap
ngs_physical_networks = physnet1,physnet2

[1]
https://specs.openstack.org/openstack/ironic-specs/specs/not-implemented/physical-network-awareness.html

Change-Id: I77a8247f6152fd0133c8f5a325ca20cd35fa669d
Closes-Bug: #1735394