### PR TITLE
Adds ngs_switchport_mode config option to Dell PowerConnect driver

### DIFF
--- a/networking_generic_switch/devices/__init__.py
+++ b/networking_generic_switch/devices/__init__.py
@@ -33,6 +33,7 @@ NGS_INTERNAL_OPTS = [
     {'name': 'ngs_ssh_connect_timeout', 'default': 60},
     {'name': 'ngs_ssh_connect_interval', 'default': 10},
     {'name': 'ngs_max_connections', 'default': 1},
+    {'name': 'ngs_switchport_mode', 'default': 'access'}
 ]
 
 

--- a/networking_generic_switch/exceptions.py
+++ b/networking_generic_switch/exceptions.py
@@ -21,6 +21,10 @@ class GenericSwitchException(exceptions.NeutronException):
     message = _("%(method)s failed.")
 
 
+class GenericSwitchConfigException(exceptions.NeutronException):
+    message = _("%(option)s must be one of: %(allowed_options)s")
+
+
 class GenericSwitchEntrypointLoadError(GenericSwitchException):
     message = _("Failed to load entrypoint %(ep)s: %(err)s")
 

--- a/releasenotes/notes/add-switchmode-option-to-dell-powerconnect-87718a84430444ef.yaml
+++ b/releasenotes/notes/add-switchmode-option-to-dell-powerconnect-87718a84430444ef.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Adds a new config option, ``ngs_switchport_mode`` to the Dell
+    PowerConnect driver.


### PR DESCRIPTION
This allows the PowerConnect switches to configured with switchport
mode set to general.

Change-Id: Id9b506a043a8756393b302f304ca7432819bebd5
Story: 2002940
Task: 22932