### PR TITLE
Retry junos operations on harmless warnings

### DIFF
--- a/networking_generic_switch/devices/netmiko_devices/juniper.py
+++ b/networking_generic_switch/devices/netmiko_devices/juniper.py
@@ -106,17 +106,25 @@ class Juniper(netmiko_devices.NetmikoSwitch):
         # another session has a lock. We use a retry mechanism to work around
         # this.
 
-        class DBLocked(Exception):
+        class BaseRetryable(Exception):
+            """Base class for retryable exceptions."""
+
+        class DBLocked(BaseRetryable):
             """Switch configuration DB is locked by another user."""
+
+        class WarningStmtExists(BaseRetryable):
+            """Attempting to add a statement that already exists."""
+
+        class WarningStmtNotExist(BaseRetryable):
+            """Attempting to remove a statement that does not exist."""
 
         @tenacity.retry(
             # Log a message after each failed attempt.
             after=tenacity.after_log(LOG, logging.DEBUG),
             # Reraise exceptions if our final attempt fails.
             reraise=True,
-            # Retry on failure to commit the configuration due to the DB
-            # being locked by another session.
-            retry=(tenacity.retry_if_exception_type(DBLocked)),
+            # Retry on certain failures.
+            retry=(tenacity.retry_if_exception_type(BaseRetryable)),
             # Stop after the configured timeout.
             stop=tenacity.stop_after_delay(
                 int(self.ngs_config['ngs_commit_timeout'])),
@@ -129,11 +137,27 @@ class Juniper(netmiko_devices.NetmikoSwitch):
                 net_connect.commit()
             except ValueError as e:
                 # Netmiko raises ValueError on commit failure, and appends the
-                # CLI output to the exception message. Raise a more specific
-                # exception for a locked DB, on which tenacity will retry.
-                DB_LOCKED_MSG = "error: configuration database locked"
-                if DB_LOCKED_MSG in str(e):
-                    raise DBLocked(e)
+                # CLI output to the exception message.
+
+                # Certain strings indicate a temporary failure, or a harmless
+                # warning. In these cases we should retry the operation. We
+                # don't ignore warning messages, in case there is some other
+                # less benign cause for the failure.
+                retryable_msgs = {
+                    # Concurrent access to the switch can lead to contention
+                    # for the configuration database lock, and potentially
+                    # failure to commit changes with the following message.
+                    "error: configuration database locked": DBLocked,
+                    # Can be caused by concurrent configuration if two sessions
+                    # attempt to remove the same statement.
+                    "warning: statement does not exist": WarningStmtNotExist,
+                    # Can be caused by concurrent configuration if two sessions
+                    # attempt to add the same statement.
+                    "warning: statement already exists": WarningStmtExists,
+                }
+                for msg in retryable_msgs:
+                    if msg in str(e):
+                        raise retryable_msgs[msg](e)
                 raise
 
         try:
@@ -141,6 +165,13 @@ class Juniper(netmiko_devices.NetmikoSwitch):
         except DBLocked as e:
             msg = ("Reached timeout waiting for switch configuration DB lock. "
                    "Configuration might not be committed. Error: %s" % str(e))
+            LOG.error(msg)
+            raise exc.GenericSwitchNetmikoConfigError(
+                config=device_utils.sanitise_config(self.config), error=msg)
+        except (WarningStmtNotExist, WarningStmtExists) as e:
+            msg = ("Reached timeout while attempting to apply configuration. "
+                   "This is likely to be caused by multiple sessions "
+                   "configuring the device concurrently. Error: %s" % str(e))
             LOG.error(msg)
             raise exc.GenericSwitchNetmikoConfigError(
                 config=device_utils.sanitise_config(self.config), error=msg)

--- a/networking_generic_switch/tests/unit/netmiko/test_juniper.py
+++ b/networking_generic_switch/tests/unit/netmiko/test_juniper.py
@@ -105,8 +105,32 @@ class TestNetmikoJuniper(test_netmiko_base.NetmikoSwitchTestBase):
     @mock.patch.object(netmiko_devices.tenacity, 'wait_fixed',
                        return_value=tenacity.wait_fixed(0.01))
     @mock.patch.object(netmiko_devices.tenacity, 'stop_after_delay',
+                       return_value=tenacity.stop_after_attempt(2))
+    def test_save_configuration_db_locked(self, m_stop, m_wait):
+        mock_connection = mock.Mock()
+        output = """
+error: configuration database locked by:
+  user terminal p0 (pid 1234) on since 2017-1-1 00:00:00 UTC
+      exclusive private [edit]
+
+{master:0}[edit]"""
+        mock_connection.commit.side_effect = [
+            ValueError(
+                "Commit failed with the following errors:\n\n{0}"
+                .format(output)
+            ),
+            None
+        ]
+
+        self.switch.save_configuration(mock_connection)
+        m_stop.assert_called_once_with(60)
+        m_wait.assert_called_once_with(5)
+
+    @mock.patch.object(netmiko_devices.tenacity, 'wait_fixed',
+                       return_value=tenacity.wait_fixed(0.01))
+    @mock.patch.object(netmiko_devices.tenacity, 'stop_after_delay',
                        return_value=tenacity.stop_after_delay(0.1))
-    def test_save_configuration_timeout(self, m_stop, m_wait):
+    def test_save_configuration_db_locked_timeout(self, m_stop, m_wait):
         mock_connection = mock.Mock()
         output = """
 error: configuration database locked by:
@@ -119,6 +143,102 @@ error: configuration database locked by:
 
         self.assertRaisesRegexp(exc.GenericSwitchNetmikoConfigError,
                                 "Reached timeout waiting for",
+                                self.switch.save_configuration,
+                                mock_connection)
+        self.assertGreater(mock_connection.commit.call_count, 1)
+        m_stop.assert_called_once_with(60)
+        m_wait.assert_called_once_with(5)
+
+    @mock.patch.object(netmiko_devices.tenacity, 'wait_fixed',
+                       return_value=tenacity.wait_fixed(0.01))
+    @mock.patch.object(netmiko_devices.tenacity, 'stop_after_delay',
+                       return_value=tenacity.stop_after_attempt(2))
+    def test_save_configuration_warn_already_exists(self, m_stop, m_wait):
+        mock_connection = mock.Mock()
+        output = """
+[edit interfaces xe-0/0/1 unit 0 family ethernet-switching vlan]
+  'members 1234'
+        warning: statement already exists
+
+{master:0}[edit]"""
+        mock_connection.commit.side_effect = [
+            ValueError(
+                "Commit failed with the following errors:\n\n{0}"
+                .format(output)
+            ),
+            None
+        ]
+
+        self.switch.save_configuration(mock_connection)
+        m_stop.assert_called_once_with(60)
+        m_wait.assert_called_once_with(5)
+
+    @mock.patch.object(netmiko_devices.tenacity, 'wait_fixed',
+                       return_value=tenacity.wait_fixed(0.01))
+    @mock.patch.object(netmiko_devices.tenacity, 'stop_after_delay',
+                       return_value=tenacity.stop_after_delay(0.1))
+    def test_save_configuration_warn_already_exists_timeout(
+            self, m_stop, m_wait):
+        mock_connection = mock.Mock()
+        output = """
+[edit interfaces xe-0/0/1 unit 0 family ethernet-switching vlan]
+  'members 1234'
+        warning: statement already exists
+
+{master:0}[edit]"""
+        mock_connection.commit.side_effect = ValueError(
+            "Commit failed with the following errors:\n\n{0}".format(output))
+
+        self.assertRaisesRegexp(exc.GenericSwitchNetmikoConfigError,
+                                "Reached timeout while attempting",
+                                self.switch.save_configuration,
+                                mock_connection)
+        self.assertGreater(mock_connection.commit.call_count, 1)
+        m_stop.assert_called_once_with(60)
+        m_wait.assert_called_once_with(5)
+
+    @mock.patch.object(netmiko_devices.tenacity, 'wait_fixed',
+                       return_value=tenacity.wait_fixed(0.01))
+    @mock.patch.object(netmiko_devices.tenacity, 'stop_after_delay',
+                       return_value=tenacity.stop_after_attempt(2))
+    def test_save_configuration_warn_does_not_exist(self, m_stop, m_wait):
+        mock_connection = mock.Mock()
+        output = """
+[edit interfaces xe-0/0/1 unit 0 family ethernet-switching vlan]
+  'members 1234'
+        warning: statement does not exist
+
+{master:0}[edit]"""
+        mock_connection.commit.side_effect = [
+            ValueError(
+                "Commit failed with the following errors:\n\n{0}"
+                .format(output)
+            ),
+            None
+        ]
+
+        self.switch.save_configuration(mock_connection)
+        m_stop.assert_called_once_with(60)
+        m_wait.assert_called_once_with(5)
+
+    @mock.patch.object(netmiko_devices.tenacity, 'wait_fixed',
+                       return_value=tenacity.wait_fixed(0.01))
+    @mock.patch.object(netmiko_devices.tenacity, 'stop_after_delay',
+                       return_value=tenacity.stop_after_delay(0.1))
+    def test_save_configuration_warn_does_not_exist_timeout(
+            self, m_stop, m_wait):
+        mock_connection = mock.Mock()
+        output = """
+[edit interfaces xe-0/0/1 unit 0 family ethernet-switching vlan]
+  'members 1234'
+        warning: statement does not exist
+
+{master:0}[edit]"""
+        mock_connection.commit.side_effect = ValueError(
+            "Commit failed with the following errors:\n\n{0}".format(output))
+
+        self.assertRaisesRegexp(exc.GenericSwitchNetmikoConfigError,
+                                "Reached timeout while attempting",
                                 self.switch.save_configuration,
                                 mock_connection)
         self.assertGreater(mock_connection.commit.call_count, 1)

--- a/releasenotes/notes/junos-retry-warnings-f2b004fe99d7770d.yaml
+++ b/releasenotes/notes/junos-retry-warnings-f2b004fe99d7770d.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixes an issue with the ``netmiko_juniper`` driver, which could
+    unnecessarily fail operations if concurrent configuration of a switch is
+    performed. See `story 2006220
+    <https://storyboard.openstack.org/#!/story/2006220>`__ for details.


### PR DESCRIPTION
Sometimes juniper devices emit a warning when committing configuration
changes. For example the following may be seen if another session
concurrently removes the same statement:

warning: statement does not exist

And this one if another session concurrently adds the same statement:

warning: statement already exists

Netmiko treats these as failures, and the operation is failed. However,
the operation has succeeded and this is just informational. In
these cases we should retry the operation, since the warning
will not appear again.

Change-Id: I4bece2d63ce4bb5bbd2cc6dcf1b9e3e6a45bed3e
Story: 2006220
Task: 35818