### PR TITLE
Port patches on stackhpc/rocky to stable/stein

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,34 @@
+---
+language: python
+python: "2.7"
+
+# Run jobs in VMs - sudo is required by ansible tests.
+sudo: required
+
+# Install ansible
+addons:
+  apt:
+    packages:
+      - gcc
+      - python-apt
+      - python-virtualenv
+      - realpath
+
+# Create a build matrix for the different test jobs.
+env:
+  matrix:
+    # Run python style checks.
+    - TOX_ENV=pep8
+    # Build documentation.
+    - TOX_ENV=docs
+    # Run python2.7 unit tests.
+    - TOX_ENV=py27
+
+install:
+  # Install tox in a virtualenv to ensure we have an up to date version.
+  - pip install -U pip
+  - pip install tox
+
+script:
+  # Run the tox environment.
+  - tox -e ${TOX_ENV}

--- a/networking_generic_switch/generic_switch_mech.py
+++ b/networking_generic_switch/generic_switch_mech.py
@@ -45,7 +45,6 @@ class GenericSwitchDriver(api.MechanismDriver):
         LOG.info('Devices %s have been loaded', self.switches.keys())
         if not self.switches:
             LOG.error('No devices have been loaded')
-        self.warned_del_network = False
 
     def create_network_precommit(self, context):
         """Allocate resources for a new network.
@@ -165,22 +164,7 @@ class GenericSwitchDriver(api.MechanismDriver):
             # Delete vlan on all switches from this driver
             for switch_name, switch in self._get_devices_by_physnet(physnet):
                 try:
-                    # NOTE(mgoddard): The del_network method was modified to
-                    # accept the network ID. The switch object may still be
-                    # implementing the old interface, so retry on a TypeError.
-                    try:
-                        switch.del_network(segmentation_id, network['id'])
-                    except TypeError:
-                        if not self.warned_del_network:
-                            msg = (
-                                'The del_network device method should accept '
-                                'the network ID. Falling back to just the '
-                                'segmentation ID for %(device)s. This '
-                                'transitional support will be removed in the '
-                                'Rocky release')
-                            LOG.warn(msg, {'device': switch_name})
-                            self.warned_del_network = True
-                        switch.del_network(segmentation_id)
+                    switch.del_network(segmentation_id, network['id'])
                 except Exception as e:
                     LOG.error("Failed to delete network %(net_id)s "
                               "on device: %(switch)s, reason: %(exc)s",

--- a/networking_generic_switch/tests/unit/test_generic_switch_mech.py
+++ b/networking_generic_switch/tests/unit/test_generic_switch_mech.py
@@ -180,26 +180,6 @@ class TestGenericSwitchDriver(unittest.TestCase):
         self.assertIn('Failed to delete network', m_log.error.call_args[0][0])
         self.assertNotIn('has been deleted', m_log.info.call_args[0][0])
 
-    @mock.patch('networking_generic_switch.generic_switch_mech.LOG')
-    def test_delete_network_postcommit_no_network_id(self, m_log, m_list):
-        driver = gsm.GenericSwitchDriver()
-        driver.initialize()
-        mock_context = mock.create_autospec(driver_context.NetworkContext)
-        mock_context.current = {'id': 22,
-                                'provider:network_type': 'vlan',
-                                'provider:segmentation_id': 22,
-                                'provider:physical_network': 'physnet1'}
-        self.switch_mock.del_network.side_effect = TypeError
-
-        driver.delete_network_postcommit(mock_context)
-        self.assertEqual([mock.call(22, 22), mock.call(22)],
-                         self.switch_mock.del_network.call_args_list)
-        self.assertEqual(m_log.warn.call_count, 1)
-
-        # Ensure the warning is only logged once.
-        driver.delete_network_postcommit(mock_context)
-        self.assertEqual(m_log.warn.call_count, 1)
-
     def test_delete_port_postcommit(self, m_list):
         driver = gsm.GenericSwitchDriver()
         driver.initialize()

--- a/networking_generic_switch/tests/unit/test_generic_switch_mech.py
+++ b/networking_generic_switch/tests/unit/test_generic_switch_mech.py
@@ -97,18 +97,40 @@ class TestGenericSwitchDriver(unittest.TestCase):
     def test_create_network_postcommit_failure(self, m_log, m_list):
         driver = gsm.GenericSwitchDriver()
         driver.initialize()
-        self.switch_mock.add_network.side_effect = Exception('boom')
+        self.switch_mock.add_network.side_effect = ValueError('boom')
         mock_context = mock.create_autospec(driver_context.NetworkContext)
         mock_context.current = {'id': 22,
                                 'provider:network_type': 'vlan',
                                 'provider:segmentation_id': 22,
                                 'provider:physical_network': 'physnet1'}
 
-        driver.create_network_postcommit(mock_context)
+        self.assertRaisesRegexp(ValueError, "boom",
+                                driver.create_network_postcommit, mock_context)
         self.switch_mock.add_network.assert_called_once_with(22, 22)
         self.assertEqual(1, m_log.error.call_count)
         self.assertIn('Failed to create network', m_log.error.call_args[0][0])
         self.assertNotIn('has been added', m_log.info.call_args[0][0])
+
+    @mock.patch('networking_generic_switch.generic_switch_mech.LOG')
+    def test_create_network_postcommit_failure_multiple(self, m_log, m_list):
+        m_list.return_value = {
+            'foo': {'device_type': 'bar', 'spam': 'ham', 'ip': 'ip'},
+            'bar': {'device_type': 'bar', 'spam': 'ham', 'ip': 'ip'},
+        }
+        driver = gsm.GenericSwitchDriver()
+        driver.initialize()
+        self.switch_mock.add_network.side_effect = ValueError('boom')
+        mock_context = mock.create_autospec(driver_context.NetworkContext)
+        mock_context.current = {'id': 22,
+                                'provider:network_type': 'vlan',
+                                'provider:segmentation_id': 22,
+                                'provider:physical_network': 'physnet1'}
+
+        self.assertRaisesRegexp(ValueError, "boom",
+                                driver.create_network_postcommit, mock_context)
+        self.switch_mock.add_network.assert_called_once_with(22, 22)
+        self.assertEqual(1, m_log.error.call_count)
+        self.assertIn('Failed to create network', m_log.error.call_args[0][0])
 
     def test_delete_network_postcommit(self, m_list):
         driver = gsm.GenericSwitchDriver()
@@ -167,18 +189,41 @@ class TestGenericSwitchDriver(unittest.TestCase):
     def test_delete_network_postcommit_failure(self, m_log, m_list):
         driver = gsm.GenericSwitchDriver()
         driver.initialize()
-        self.switch_mock.del_network.side_effect = Exception('boom')
+        self.switch_mock.del_network.side_effect = ValueError('boom')
         mock_context = mock.create_autospec(driver_context.NetworkContext)
         mock_context.current = {'id': 22,
                                 'provider:network_type': 'vlan',
                                 'provider:segmentation_id': 22,
                                 'provider:physical_network': 'physnet1'}
 
-        driver.delete_network_postcommit(mock_context)
+        self.assertRaisesRegexp(ValueError, "boom",
+                                driver.delete_network_postcommit, mock_context)
         self.switch_mock.del_network.assert_called_once_with(22, 22)
         self.assertEqual(1, m_log.error.call_count)
         self.assertIn('Failed to delete network', m_log.error.call_args[0][0])
         self.assertNotIn('has been deleted', m_log.info.call_args[0][0])
+
+    @mock.patch('networking_generic_switch.generic_switch_mech.LOG')
+    def test_delete_network_postcommit_failure_multiple(self, m_log, m_list):
+        m_list.return_value = {
+            'foo': {'device_type': 'bar', 'spam': 'ham', 'ip': 'ip'},
+            'bar': {'device_type': 'bar', 'spam': 'ham', 'ip': 'ip'},
+        }
+        driver = gsm.GenericSwitchDriver()
+        driver.initialize()
+        self.switch_mock.del_network.side_effect = ValueError('boom')
+        mock_context = mock.create_autospec(driver_context.NetworkContext)
+        mock_context.current = {'id': 22,
+                                'provider:network_type': 'vlan',
+                                'provider:segmentation_id': 22,
+                                'provider:physical_network': 'physnet1'}
+
+        self.assertRaisesRegexp(ValueError, "boom",
+                                driver.delete_network_postcommit, mock_context)
+        self.switch_mock.del_network.assert_called_with(22, 22)
+        self.assertEqual(2, self.switch_mock.del_network.call_count)
+        self.assertEqual(2, m_log.error.call_count)
+        self.assertIn('Failed to delete network', m_log.error.call_args[0][0])
 
     def test_delete_port_postcommit(self, m_list):
         driver = gsm.GenericSwitchDriver()

--- a/releasenotes/notes/junos-retry-warnings-f2b004fe99d7770d.yaml
+++ b/releasenotes/notes/junos-retry-warnings-f2b004fe99d7770d.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixes an issue with the ``netmiko_juniper`` driver, which could
+    unnecessarily fail operations if concurrent configuration of a switch is
+    performed. See `story 2006220
+    <https://storyboard.openstack.org/#!/story/2006220>`__ for details.

--- a/releasenotes/notes/net-add-del-failure-f4ea1118bc1f9d28.yaml
+++ b/releasenotes/notes/net-add-del-failure-f4ea1118bc1f9d28.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixes an issue when creating or deleting a network, a failure to apply this
+    change to any device would not cause the operation to fail. This could
+    leave the network in an inconsistent state. See story 2006222
+    <https://storyboard.openstack.org/#!/story/2006222>`__ for details.

--- a/releasenotes/notes/remove-del_network-transitional-2f5742f7cafa2276.yaml
+++ b/releasenotes/notes/remove-del_network-transitional-2f5742f7cafa2276.yaml
@@ -3,4 +3,4 @@ upgrade:
   - |
     Removes support for device drivers that accept only a single argument for
     their ``del_network`` method.  All device drivers must now accept a
-    segmentation ID and a network ID in their ``del_method``.
+    segmentation ID and a network ID in their ``del_network`` method.

--- a/releasenotes/notes/remove-del_network-transitional-2f5742f7cafa2276.yaml
+++ b/releasenotes/notes/remove-del_network-transitional-2f5742f7cafa2276.yaml
@@ -1,0 +1,6 @@
+---
+upgrade:
+  - |
+    Removes support for device drivers that accept only a single argument for
+    their ``del_network`` method.  All device drivers must now accept a
+    segmentation ID and a network ID in their ``del_method``.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@
 # process, which may cause wedges in the gate later.
 stevedore>=1.20.0 # Apache-2.0
 netmiko>=2.0.2 # MIT
-neutron>=13.0.0.0b1 # Apache-2.0
 neutron-lib>=1.18.0 # Apache-2.0
 oslo.config>=5.2.0 # Apache-2.0
 oslo.i18n>=3.15.3 # Apache-2.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -17,3 +17,5 @@ doc8>=0.6.0 # Apache-2.0
 
 # Tempest plugin requirements
 futurist>=1.2.0 # Apache-2.0
+
+neutron>=13.0.0.0b1,<14 # Apache-2.0


### PR DESCRIPTION
Changes on stackhpc/rocky compared to stable/rocky
=====================
pick 318aba9 Detection of config errors for netmiko drivers
pick 97701b2 Detection of errors for Dell PowerConnect devices
pick 36daa2b Support disabling inactive links
pick bc27fd0 Support disabling inactive links for Juniper
pick f87e881 Add a TravisCI configuration file to test downstream changes
pick 60a8d88 Remove neutron from requirements
pick 423a0f4 Retry junos operations on harmless warnings
pick 928af6d Remove transitional single argument del_network support
pick ac1b5ff Fail if creation or deletion of a network on a device fails

picks
=========

```
[will@juno networking-generic-switch]$ cat runme.sh 
while read -r line; do
    commit=`echo $line | awk '{ print $2}'`
    id=`git log --format=%B -n 1 $commit | grep Change-Id | awk '{print $2}'`
    if [ "$id" = "" ] || [ $(git log openstack/stable/stein --grep $id | wc -l)  -eq 0 ]; then
        echo $line
    fi
done
```
```
[will@juno networking-generic-switch]$ bash runme.sh < patches
``` 
pick f87e881 Add a TravisCI configuration file to test downstream changes
pick 60a8d88 Remove neutron from requirements
pick 423a0f4 Retry junos operations on harmless warnings
pick 928af6d Remove transitional single argument del_network support
pick ac1b5ff Fail if creation or deletion of a network on a device fails