### PR TITLE
Allow network name format to be configured

### DIFF
--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -214,3 +214,23 @@ using the ``ngs_disable_inactive_ports`` flag::
 This is currently supported by the following devices:
 
 * Juniper Junos OS
+
+Network Name Format
+===================
+
+By default, when a network is created on a switch, if the switch supports
+assigning names to VLANs, they are assigned a name of the neutron network UUID.
+For example::
+
+    8f60256e4b6343bf873026036606ce5e
+
+It is possible to use a different format for the network name using the
+``ngs_network_name_format`` option. This option uses Python string formatting
+syntax, and accepts the parameters ``{network_id}`` and ``{segmentation_id}``.
+For example::
+
+    [genericswitch:device-hostname]
+    ngs_network_name_format = neutron-{network_id}-{segmentation_id}
+
+Some switches have issues assigning VLANs a name that starts with a number,
+and this configuration option can be used to avoid this.

--- a/networking_generic_switch/devices/__init__.py
+++ b/networking_generic_switch/devices/__init__.py
@@ -37,6 +37,9 @@ NGS_INTERNAL_OPTS = [
     {'name': 'ngs_switchport_mode', 'default': 'access'},
     # If True, disable switch ports that are not in use.
     {'name': 'ngs_disable_inactive_ports', 'default': False},
+    # String format for network name to configure on switches.
+    # Accepts {network_id} and {segmentation_id} formatting options.
+    {'name': 'ngs_network_name_format', 'default': '{network_id}'},
 ]
 
 
@@ -81,6 +84,19 @@ class GenericSwitchDevice(object):
                 self.ngs_config[opt_name] = opt['default']
         self.config = device_cfg
 
+        self._validate_network_name_format()
+
+    def _validate_network_name_format(self):
+        """Validate the network name format configuration option."""
+        network_name_format = self.ngs_config['ngs_network_name_format']
+        # The format can include '{network_id}' and '{segmentation_id}'.
+        try:
+            network_name_format.format(network_id='dummy',
+                                       segmentation_id='dummy')
+        except (IndexError, KeyError) as exc:
+            raise gsw_exc.GenericSwitchNetworkNameFormatInvalid(
+                name_format=network_name_format)
+
     def _get_trunk_ports(self):
         """Return a list of trunk ports on this switch."""
         trunk_ports = self.ngs_config.get('ngs_trunk_ports')
@@ -107,6 +123,17 @@ class GenericSwitchDevice(object):
     def _disable_inactive_ports(self):
         """Return whether inactive ports should be disabled."""
         return self._str_to_bool(self.ngs_config['ngs_disable_inactive_ports'])
+
+    def _get_network_name(self, network_id, segmentation_id):
+        """Return a network name to configure on switches.
+
+        :param network_id: ID of the network.
+        :param segmentation_id: segmentation ID of the network.
+        :returns: a formatted network name.
+        """
+        network_name_format = self.ngs_config['ngs_network_name_format']
+        return network_name_format.format(network_id=network_id,
+                                          segmentation_id=segmentation_id)
 
     @abc.abstractmethod
     def add_network(self, segmentation_id, network_id):

--- a/networking_generic_switch/devices/netmiko_devices/__init__.py
+++ b/networking_generic_switch/devices/netmiko_devices/__init__.py
@@ -165,10 +165,15 @@ class NetmikoSwitch(devices.GenericSwitchDevice):
     def add_network(self, segmentation_id, network_id):
         # NOTE(zhenguo): Remove dashes from uuid as on most devices 32 chars
         # is the max length of vlan name.
+
         network_id = uuid.UUID(network_id).hex
+        network_name = self._get_network_name(network_id, segmentation_id)
+        # NOTE(mgoddard): Pass network_id and segmentation_id for drivers not
+        # yet using network_name.
         cmds = self._format_commands(self.ADD_NETWORK,
                                      segmentation_id=segmentation_id,
-                                     network_id=network_id)
+                                     network_id=network_id,
+                                     network_name=network_name)
         for port in self._get_trunk_ports():
             cmds += self._format_commands(self.ADD_NETWORK_TO_TRUNK,
                                           port=port,
@@ -185,9 +190,13 @@ class NetmikoSwitch(devices.GenericSwitchDevice):
             cmds += self._format_commands(self.REMOVE_NETWORK_FROM_TRUNK,
                                           port=port,
                                           segmentation_id=segmentation_id)
+        network_name = self._get_network_name(network_id, segmentation_id)
+        # NOTE(mgoddard): Pass network_id and segmentation_id for drivers not
+        # yet using network_name.
         cmds += self._format_commands(self.DELETE_NETWORK,
                                       segmentation_id=segmentation_id,
-                                      network_id=network_id)
+                                      network_id=network_id,
+                                      network_name=network_name)
         output = self.send_commands_to_device(cmds)
         self.check_output(output, 'delete network')
 
@@ -214,10 +223,15 @@ class NetmikoSwitch(devices.GenericSwitchDevice):
                                      segmentation_id=segmentation_id)
         ngs_port_default_vlan = self._get_port_default_vlan()
         if ngs_port_default_vlan:
+            # NOTE(mgoddard): Pass network_id and segmentation_id for drivers
+            # not yet using network_name.
+            network_name = self._get_network_name(ngs_port_default_vlan,
+                                                  ngs_port_default_vlan)
             cmds += self._format_commands(
                 self.ADD_NETWORK,
                 segmentation_id=ngs_port_default_vlan,
-                network_id=ngs_port_default_vlan)
+                network_id=ngs_port_default_vlan,
+                network_name=network_name)
             cmds += self._format_commands(
                 self.PLUG_PORT_TO_NETWORK,
                 port=port,

--- a/networking_generic_switch/devices/netmiko_devices/arista.py
+++ b/networking_generic_switch/devices/netmiko_devices/arista.py
@@ -18,7 +18,7 @@ from networking_generic_switch.devices import netmiko_devices
 class AristaEos(netmiko_devices.NetmikoSwitch):
     ADD_NETWORK = (
         'vlan {segmentation_id}',
-        'name {network_id}',
+        'name {network_name}',
     )
 
     DELETE_NETWORK = (

--- a/networking_generic_switch/devices/netmiko_devices/brocade.py
+++ b/networking_generic_switch/devices/netmiko_devices/brocade.py
@@ -26,7 +26,7 @@ LOG = logging.getLogger(__name__)
 class BrocadeFastIron(netmiko_devices.NetmikoSwitch):
     ADD_NETWORK = (
         'vlan {segmentation_id} by port',
-        'name {network_id}',
+        'name {network_name}',
     )
 
     DELETE_NETWORK = (

--- a/networking_generic_switch/devices/netmiko_devices/cisco.py
+++ b/networking_generic_switch/devices/netmiko_devices/cisco.py
@@ -18,7 +18,7 @@ from networking_generic_switch.devices import netmiko_devices
 class CiscoIos(netmiko_devices.NetmikoSwitch):
     ADD_NETWORK = (
         'vlan {segmentation_id}',
-        'name {network_id}',
+        'name {network_name}',
     )
 
     DELETE_NETWORK = (

--- a/networking_generic_switch/devices/netmiko_devices/dell.py
+++ b/networking_generic_switch/devices/netmiko_devices/dell.py
@@ -23,7 +23,7 @@ class DellNos(netmiko_devices.NetmikoSwitch):
 
     ADD_NETWORK = (
         'interface vlan {segmentation_id}',
-        'name {network_id}',
+        'name {network_name}',
         'exit',
     )
 

--- a/networking_generic_switch/devices/netmiko_devices/juniper.py
+++ b/networking_generic_switch/devices/netmiko_devices/juniper.py
@@ -33,11 +33,11 @@ JUNIPER_INTERNAL_OPTS = [
 class Juniper(netmiko_devices.NetmikoSwitch):
 
     ADD_NETWORK = (
-        'set vlans {network_id} vlan-id {segmentation_id}',
+        'set vlans {network_name} vlan-id {segmentation_id}',
     )
 
     DELETE_NETWORK = (
-        'delete vlans {network_id}',
+        'delete vlans {network_name}',
     )
 
     PLUG_PORT_TO_NETWORK = (

--- a/networking_generic_switch/devices/netmiko_devices/ruijie.py
+++ b/networking_generic_switch/devices/netmiko_devices/ruijie.py
@@ -18,7 +18,7 @@ from networking_generic_switch.devices import netmiko_devices
 class Ruijie(netmiko_devices.NetmikoSwitch):
     ADD_NETWORK = (
         'vlan {segmentation_id}',
-        'name {network_id}',
+        'name {network_name}',
     )
 
     DELETE_NETWORK = (

--- a/networking_generic_switch/exceptions.py
+++ b/networking_generic_switch/exceptions.py
@@ -29,6 +29,12 @@ class GenericSwitchEntrypointLoadError(GenericSwitchException):
     message = _("Failed to load entrypoint %(ep)s: %(err)s")
 
 
+class GenericSwitchNetworkNameFormatInvalid(GenericSwitchException):
+    message = _("Invalid value for 'ngs_network_name_format': "
+                "%(name_format)s. Valid format options include 'network_id' "
+                "and 'segmentation_id'")
+
+
 class GenericSwitchNetmikoMethodError(GenericSwitchException):
     message = _("Can not parse arguments: commands %(cmds)s, args %(args)s")
 

--- a/networking_generic_switch/tests/unit/netmiko/test_arista_eos.py
+++ b/networking_generic_switch/tests/unit/netmiko/test_arista_eos.py
@@ -61,8 +61,9 @@ class TestNetmikoAristaEos(test_netmiko_base.NetmikoSwitchTestBase):
         cmd_set = self.switch._format_commands(
             arista.AristaEos.ADD_NETWORK,
             segmentation_id=22,
-            network_id=22)
-        self.assertEqual(cmd_set, ['vlan 22', 'name 22'])
+            network_id=22,
+            network_name='vlan-22')
+        self.assertEqual(cmd_set, ['vlan 22', 'name vlan-22'])
 
         cmd_set = self.switch._format_commands(
             arista.AristaEos.DELETE_NETWORK,

--- a/networking_generic_switch/tests/unit/netmiko/test_brocade_fastiron.py
+++ b/networking_generic_switch/tests/unit/netmiko/test_brocade_fastiron.py
@@ -73,8 +73,9 @@ class TestNetmikoBrocadeFastIron(test_netmiko_base.NetmikoSwitchTestBase):
         cmd_set = self.switch._format_commands(
             brocade.BrocadeFastIron.ADD_NETWORK,
             segmentation_id=22,
-            network_id=22)
-        self.assertEqual(cmd_set, ['vlan 22 by port', 'name 22'])
+            network_id=22,
+            network_name='vlan-22')
+        self.assertEqual(cmd_set, ['vlan 22 by port', 'name vlan-22'])
 
         cmd_set = self.switch._format_commands(
             brocade.BrocadeFastIron.DELETE_NETWORK,

--- a/networking_generic_switch/tests/unit/netmiko/test_cisco_ios.py
+++ b/networking_generic_switch/tests/unit/netmiko/test_cisco_ios.py
@@ -60,8 +60,9 @@ class TestNetmikoCiscoIos(test_netmiko_base.NetmikoSwitchTestBase):
         cmd_set = self.switch._format_commands(
             cisco.CiscoIos.ADD_NETWORK,
             segmentation_id=22,
-            network_id=22)
-        self.assertEqual(cmd_set, ['vlan 22', 'name 22'])
+            network_id=22,
+            network_name='vlan-22')
+        self.assertEqual(cmd_set, ['vlan 22', 'name vlan-22'])
 
         cmd_set = self.switch._format_commands(
             cisco.CiscoIos.DELETE_NETWORK,

--- a/networking_generic_switch/tests/unit/netmiko/test_dell.py
+++ b/networking_generic_switch/tests/unit/netmiko/test_dell.py
@@ -82,8 +82,10 @@ class TestNetmikoDellNos(test_netmiko_base.NetmikoSwitchTestBase):
         cmd_set = self.switch._format_commands(
             dell.DellNos.ADD_NETWORK,
             segmentation_id=22,
-            network_id=22)
-        self.assertEqual(cmd_set, ['interface vlan 22', 'name 22', 'exit'])
+            network_id=22,
+            network_name='vlan-22')
+        self.assertEqual(cmd_set,
+                         ['interface vlan 22', 'name vlan-22', 'exit'])
 
         cmd_set = self.switch._format_commands(
             dell.DellNos.DELETE_NETWORK,

--- a/networking_generic_switch/tests/unit/netmiko/test_juniper.py
+++ b/networking_generic_switch/tests/unit/netmiko/test_juniper.py
@@ -307,14 +307,16 @@ error: configuration check-out failed
         cmd_set = self.switch._format_commands(
             juniper.Juniper.ADD_NETWORK,
             segmentation_id=22,
-            network_id=22)
-        self.assertEqual(cmd_set, ['set vlans 22 vlan-id 22'])
+            network_id=22,
+            network_name='vlan-22')
+        self.assertEqual(cmd_set, ['set vlans vlan-22 vlan-id 22'])
 
         cmd_set = self.switch._format_commands(
             juniper.Juniper.DELETE_NETWORK,
             segmentation_id=22,
-            network_id=22)
-        self.assertEqual(cmd_set, ['delete vlans 22'])
+            network_id=22,
+            network_name='vlan-22')
+        self.assertEqual(cmd_set, ['delete vlans vlan-22'])
 
         cmd_set = self.switch._format_commands(
             juniper.Juniper.PLUG_PORT_TO_NETWORK,

--- a/networking_generic_switch/tests/unit/test_devices.py
+++ b/networking_generic_switch/tests/unit/test_devices.py
@@ -78,6 +78,17 @@ class TestDeviceManager(unittest.TestCase):
         self.assertIn("fake_method", ex.exception.msg)
         self.assertIsNone(device)
 
+    @mock.patch.object(devices.GenericSwitchDevice,
+                       '_validate_network_name_format')
+    def test_driver_load_fail_validate_network_name_format(self,
+                                                           mock_validate):
+        mock_validate.side_effect = exc.GenericSwitchConfigException()
+        device_cfg = {'device_type': 'netmiko_ovs_linux'}
+        device = None
+        with self.assertRaises(exc.GenericSwitchEntrypointLoadError):
+            device = devices.device_manager(device_cfg)
+        self.assertIsNone(device)
+
     def test_driver_load_fail_load(self):
         device_cfg = {'device_type': 'fake_device'}
         device = None
@@ -93,7 +104,8 @@ class TestDeviceManager(unittest.TestCase):
                       "ngs_ssh_connect_interval": "20",
                       "ngs_trunk_ports": "port1,port2",
                       "ngs_physical_networks": "physnet1,physnet2",
-                      "ngs_port_default_vlan": "20"}
+                      "ngs_port_default_vlan": "20",
+                      "ngs_network_name_format": "net-{network_id}"}
         device = devices.device_manager(device_cfg)
         self.assertIsInstance(device, devices.GenericSwitchDevice)
         self.assertNotIn('ngs_mac_address', device.config)
@@ -110,6 +122,8 @@ class TestDeviceManager(unittest.TestCase):
         self.assertEqual('physnet1,physnet2',
                          device.ngs_config['ngs_physical_networks'])
         self.assertEqual('20', device.ngs_config['ngs_port_default_vlan'])
+        self.assertEqual('net-{network_id}',
+                         device.ngs_config['ngs_network_name_format'])
 
     def test_driver_ngs_config_defaults(self):
         device_cfg = {"device_type": 'netmiko_ovs_linux'}
@@ -120,4 +134,37 @@ class TestDeviceManager(unittest.TestCase):
         self.assertEqual(10, device.ngs_config['ngs_ssh_connect_interval'])
         self.assertNotIn('ngs_trunk_ports', device.ngs_config)
         self.assertNotIn('ngs_physical_networks', device.ngs_config)
-        self.assertNotIn('ngs_port_default_vlan', device.config)
+        self.assertNotIn('ngs_port_default_vlan', device.ngs_config)
+        self.assertEqual('{network_id}',
+                         device.ngs_config['ngs_network_name_format'])
+
+    def test__validate_network_name_format(self):
+        device_cfg = {
+            'ngs_network_name_format': '{network_id}{segmentation_id}'}
+        device = FakeDevice(device_cfg)
+        device._validate_network_name_format()
+
+    def test__validate_network_name_format_failure(self):
+        device_cfg = {'ngs_network_name_format': '{invalid}'}
+        self.assertRaisesRegexp(
+            exc.GenericSwitchNetworkNameFormatInvalid,
+            r"Invalid value for 'ngs_network_name_format'",
+            FakeDevice, device_cfg)
+
+    def test__get_network_name_default(self):
+        device = FakeDevice({})
+        name = device._get_network_name('fake-id', 22)
+        self.assertEqual('fake-id', name)
+
+    def test__get_network_name_segmentation_id(self):
+        device_cfg = {'ngs_network_name_format': '{segmentation_id}'}
+        device = FakeDevice(device_cfg)
+        name = device._get_network_name('fake-id', 22)
+        self.assertEqual('22', name)
+
+    def test__get_network_name_both(self):
+        device_cfg = {
+            'ngs_network_name_format': '{network_id}_net_{segmentation_id}'}
+        device = FakeDevice(device_cfg)
+        name = device._get_network_name('fake-id', 22)
+        self.assertEqual('fake-id_net_22', name)

--- a/releasenotes/notes/network-name-format-075f5757d599ac92.yaml
+++ b/releasenotes/notes/network-name-format-075f5757d599ac92.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Adds support for configuring the format of the name assigned to VLANs in
+    device configuration via the ``ngs_network_name_format`` device
+    configuration option.


### PR DESCRIPTION
Currently, when supported, NGS assigns the network UUID as the name of
VLANs in device configuration. Some devices, including Dell Force 10,
do not support VLAN names starting with a number. On Dell Force 10
devices this can result in the following message in neutron DEBUG logs:

Force10-switch(conf-if-vl-3293)#name 555b9c5daccb4e87997fb2b5524cf95e
    % Error: Vlan name should begin with an alphabetic character.

This change allows the format of the network name to be configured via
the 'ngs_network_name_format' configuration option.

Change-Id: Ia8a473c9e0282c5c83f595db6d37b41b52714b55
Story: 1737017
Task: 11728