### PR TITLE
Create and delete networks in parallel

### DIFF
--- a/networking_generic_switch/config.py
+++ b/networking_generic_switch/config.py
@@ -30,6 +30,16 @@ coordination_opts = [
 
 CONF.register_opts(coordination_opts, group='ngs_coordination')
 
+threadpool_opts = [
+    cfg.IntOpt('size',
+               min=1,
+               default=100,
+               help='Number of threads in pool used for parallel execution '
+                    'of operations.'),
+]
+
+CONF.register_opts(threadpool_opts, group='ngs_threadpool')
+
 
 def get_devices():
     """Parse supplied config files and fetch defined supported devices."""

--- a/networking_generic_switch/tests/unit/test_generic_switch_mech.py
+++ b/networking_generic_switch/tests/unit/test_generic_switch_mech.py
@@ -128,8 +128,9 @@ class TestGenericSwitchDriver(unittest.TestCase):
 
         self.assertRaisesRegexp(ValueError, "boom",
                                 driver.create_network_postcommit, mock_context)
-        self.switch_mock.add_network.assert_called_once_with(22, 22)
-        self.assertEqual(1, m_log.error.call_count)
+        self.switch_mock.add_network.assert_called_with(22, 22)
+        self.assertEqual(2, self.switch_mock.add_network.call_count)
+        self.assertEqual(2, m_log.error.call_count)
         self.assertIn('Failed to create network', m_log.error.call_args[0][0])
 
     def test_delete_network_postcommit(self, m_list):

--- a/releasenotes/notes/parallelise-net-create-delete-9dedbbca1a0bff47.yaml
+++ b/releasenotes/notes/parallelise-net-create-delete-9dedbbca1a0bff47.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    Adds support for parallel creation and deletion of networks. This can be
+    useful when there are many devices configured and device configuration
+    takes a long time to complete. The number of threads available to perform
+    this work is configured via the configuration option
+    ``[ngs_threadpool]size``, and defaults to 100.


### PR DESCRIPTION
Currently, networks are created and deleted on devices serially. In
systems with many devices, this can lead to these requests taking a long
time to complete.

This change executes device configuration in parallel for network
creation and deletion, which should improve this from O(N) to O(1). It
is not necessary to execute other operations in parallel, since they
only affect a single device. If we ever support multi-chassis LAG
configuration, we could configure it in parallel.

Failure handling should be as before this change, with the exception
that network creation will no longer stop after the first failed device,
since all are configured in parallel.

Change-Id: Ib257f4e7710ed6615e68c7034ff4e223bbf677b2
Story: 2006789
Task: 37328