### PR TITLE
Stein patches applied to train

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,34 @@
+---
+language: python
+python: "2.7"
+
+# Run jobs in VMs - sudo is required by ansible tests.
+sudo: required
+
+# Install ansible
+addons:
+  apt:
+    packages:
+      - gcc
+      - python-apt
+      - python-virtualenv
+      - realpath
+
+# Create a build matrix for the different test jobs.
+env:
+  matrix:
+    # Run python style checks.
+    - TOX_ENV=pep8
+    # Build documentation.
+    - TOX_ENV=docs
+    # Run python2.7 unit tests.
+    - TOX_ENV=py27
+
+install:
+  # Install tox in a virtualenv to ensure we have an up to date version.
+  - pip install -U pip
+  - pip install tox
+
+script:
+  # Run the tox environment.
+  - tox -e ${TOX_ENV}

--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -214,3 +214,23 @@ using the ``ngs_disable_inactive_ports`` flag::
 This is currently supported by the following devices:
 
 * Juniper Junos OS
+
+Network Name Format
+===================
+
+By default, when a network is created on a switch, if the switch supports
+assigning names to VLANs, they are assigned a name of the neutron network UUID.
+For example::
+
+    8f60256e4b6343bf873026036606ce5e
+
+It is possible to use a different format for the network name using the
+``ngs_network_name_format`` option. This option uses Python string formatting
+syntax, and accepts the parameters ``{network_id}`` and ``{segmentation_id}``.
+For example::
+
+    [genericswitch:device-hostname]
+    ngs_network_name_format = neutron-{network_id}-{segmentation_id}
+
+Some switches have issues assigning VLANs a name that starts with a number,
+and this configuration option can be used to avoid this.

--- a/networking_generic_switch/config.py
+++ b/networking_generic_switch/config.py
@@ -30,6 +30,16 @@ coordination_opts = [
 
 CONF.register_opts(coordination_opts, group='ngs_coordination')
 
+threadpool_opts = [
+    cfg.IntOpt('size',
+               min=1,
+               default=100,
+               help='Number of threads in pool used for parallel execution '
+                    'of operations.'),
+]
+
+CONF.register_opts(threadpool_opts, group='ngs_threadpool')
+
 
 def get_devices():
     """Parse supplied config files and fetch defined supported devices."""

--- a/networking_generic_switch/devices/netmiko_devices/__init__.py
+++ b/networking_generic_switch/devices/netmiko_devices/__init__.py
@@ -194,9 +194,13 @@ class NetmikoSwitch(devices.GenericSwitchDevice):
         # NOTE(zhenguo): Remove dashes from uuid as on most devices 32 chars
         # is the max length of vlan name.
         network_id = uuid.UUID(network_id).hex
+        network_name = self._get_network_name(network_id, segmentation_id)
+        # NOTE(mgoddard): Pass network_id and segmentation_id for drivers not
+        # yet using network_name.
         cmds = self._format_commands(self.ADD_NETWORK,
                                      segmentation_id=segmentation_id,
-                                     network_id=network_id)
+                                     network_id=network_id,
+                                     network_name=network_name)
         for port in self._get_trunk_ports():
             cmds += self._format_commands(self.ADD_NETWORK_TO_TRUNK,
                                           port=port,
@@ -213,9 +217,13 @@ class NetmikoSwitch(devices.GenericSwitchDevice):
             cmds += self._format_commands(self.REMOVE_NETWORK_FROM_TRUNK,
                                           port=port,
                                           segmentation_id=segmentation_id)
+        network_name = self._get_network_name(network_id, segmentation_id)
+        # NOTE(mgoddard): Pass network_id and segmentation_id for drivers not
+        # yet using network_name.
         cmds += self._format_commands(self.DELETE_NETWORK,
                                       segmentation_id=segmentation_id,
-                                      network_id=network_id)
+                                      network_id=network_id,
+                                      network_name=network_name)
         return self.send_commands_to_device(cmds)
 
     @check_output('plug port')
@@ -242,10 +250,15 @@ class NetmikoSwitch(devices.GenericSwitchDevice):
                                      segmentation_id=segmentation_id)
         ngs_port_default_vlan = self._get_port_default_vlan()
         if ngs_port_default_vlan:
+            # NOTE(mgoddard): Pass network_id and segmentation_id for drivers
+            # not yet using network_name.
+            network_name = self._get_network_name(ngs_port_default_vlan,
+                                                  ngs_port_default_vlan)
             cmds += self._format_commands(
                 self.ADD_NETWORK,
                 segmentation_id=ngs_port_default_vlan,
-                network_id=ngs_port_default_vlan)
+                network_id=ngs_port_default_vlan,
+                network_name=network_name)
             cmds += self._format_commands(
                 self.PLUG_PORT_TO_NETWORK,
                 port=port,

--- a/networking_generic_switch/devices/netmiko_devices/arista.py
+++ b/networking_generic_switch/devices/netmiko_devices/arista.py
@@ -18,7 +18,7 @@ from networking_generic_switch.devices import netmiko_devices
 class AristaEos(netmiko_devices.NetmikoSwitch):
     ADD_NETWORK = (
         'vlan {segmentation_id}',
-        'name {network_id}',
+        'name {network_name}',
     )
 
     DELETE_NETWORK = (

--- a/networking_generic_switch/devices/netmiko_devices/brocade.py
+++ b/networking_generic_switch/devices/netmiko_devices/brocade.py
@@ -26,7 +26,7 @@ LOG = logging.getLogger(__name__)
 class BrocadeFastIron(netmiko_devices.NetmikoSwitch):
     ADD_NETWORK = (
         'vlan {segmentation_id} by port',
-        'name {network_id}',
+        'name {network_name}',
     )
 
     DELETE_NETWORK = (

--- a/networking_generic_switch/devices/netmiko_devices/cisco.py
+++ b/networking_generic_switch/devices/netmiko_devices/cisco.py
@@ -18,7 +18,7 @@ from networking_generic_switch.devices import netmiko_devices
 class CiscoIos(netmiko_devices.NetmikoSwitch):
     ADD_NETWORK = (
         'vlan {segmentation_id}',
-        'name {network_id}',
+        'name {network_name}',
     )
 
     DELETE_NETWORK = (

--- a/networking_generic_switch/devices/netmiko_devices/dell.py
+++ b/networking_generic_switch/devices/netmiko_devices/dell.py
@@ -23,7 +23,7 @@ class DellNos(netmiko_devices.NetmikoSwitch):
 
     ADD_NETWORK = (
         'interface vlan {segmentation_id}',
-        'name {network_id}',
+        'name {network_name}',
         'exit',
     )
 

--- a/networking_generic_switch/devices/netmiko_devices/juniper.py
+++ b/networking_generic_switch/devices/netmiko_devices/juniper.py
@@ -33,11 +33,11 @@ JUNIPER_INTERNAL_OPTS = [
 class Juniper(netmiko_devices.NetmikoSwitch):
 
     ADD_NETWORK = (
-        'set vlans {network_id} vlan-id {segmentation_id}',
+        'set vlans {network_name} vlan-id {segmentation_id}',
     )
 
     DELETE_NETWORK = (
-        'delete vlans {network_id}',
+        'delete vlans {network_name}',
     )
 
     PLUG_PORT_TO_NETWORK = (

--- a/networking_generic_switch/devices/netmiko_devices/ruijie.py
+++ b/networking_generic_switch/devices/netmiko_devices/ruijie.py
@@ -18,7 +18,7 @@ from networking_generic_switch.devices import netmiko_devices
 class Ruijie(netmiko_devices.NetmikoSwitch):
     ADD_NETWORK = (
         'vlan {segmentation_id}',
-        'name {network_id}',
+        'name {network_name}',
     )
 
     DELETE_NETWORK = (

--- a/networking_generic_switch/exceptions.py
+++ b/networking_generic_switch/exceptions.py
@@ -29,6 +29,12 @@ class GenericSwitchEntrypointLoadError(GenericSwitchException):
     message = _("Failed to load entrypoint %(ep)s: %(err)s")
 
 
+class GenericSwitchNetworkNameFormatInvalid(GenericSwitchException):
+    message = _("Invalid value for 'ngs_network_name_format': "
+                "%(name_format)s. Valid format options include 'network_id' "
+                "and 'segmentation_id'")
+
+
 class GenericSwitchNetmikoMethodError(GenericSwitchException):
     message = _("Can not parse arguments: commands %(cmds)s, args %(args)s")
 

--- a/networking_generic_switch/tests/unit/netmiko/test_arista_eos.py
+++ b/networking_generic_switch/tests/unit/netmiko/test_arista_eos.py
@@ -61,8 +61,9 @@ class TestNetmikoAristaEos(test_netmiko_base.NetmikoSwitchTestBase):
         cmd_set = self.switch._format_commands(
             arista.AristaEos.ADD_NETWORK,
             segmentation_id=22,
-            network_id=22)
-        self.assertEqual(cmd_set, ['vlan 22', 'name 22'])
+            network_id=22,
+            network_name='vlan-22')
+        self.assertEqual(cmd_set, ['vlan 22', 'name vlan-22'])
 
         cmd_set = self.switch._format_commands(
             arista.AristaEos.DELETE_NETWORK,

--- a/networking_generic_switch/tests/unit/netmiko/test_brocade_fastiron.py
+++ b/networking_generic_switch/tests/unit/netmiko/test_brocade_fastiron.py
@@ -73,8 +73,9 @@ class TestNetmikoBrocadeFastIron(test_netmiko_base.NetmikoSwitchTestBase):
         cmd_set = self.switch._format_commands(
             brocade.BrocadeFastIron.ADD_NETWORK,
             segmentation_id=22,
-            network_id=22)
-        self.assertEqual(cmd_set, ['vlan 22 by port', 'name 22'])
+            network_id=22,
+            network_name='vlan-22')
+        self.assertEqual(cmd_set, ['vlan 22 by port', 'name vlan-22'])
 
         cmd_set = self.switch._format_commands(
             brocade.BrocadeFastIron.DELETE_NETWORK,

--- a/networking_generic_switch/tests/unit/netmiko/test_cisco_ios.py
+++ b/networking_generic_switch/tests/unit/netmiko/test_cisco_ios.py
@@ -60,8 +60,9 @@ class TestNetmikoCiscoIos(test_netmiko_base.NetmikoSwitchTestBase):
         cmd_set = self.switch._format_commands(
             cisco.CiscoIos.ADD_NETWORK,
             segmentation_id=22,
-            network_id=22)
-        self.assertEqual(cmd_set, ['vlan 22', 'name 22'])
+            network_id=22,
+            network_name='vlan-22')
+        self.assertEqual(cmd_set, ['vlan 22', 'name vlan-22'])
 
         cmd_set = self.switch._format_commands(
             cisco.CiscoIos.DELETE_NETWORK,

--- a/networking_generic_switch/tests/unit/netmiko/test_dell.py
+++ b/networking_generic_switch/tests/unit/netmiko/test_dell.py
@@ -82,8 +82,10 @@ class TestNetmikoDellNos(test_netmiko_base.NetmikoSwitchTestBase):
         cmd_set = self.switch._format_commands(
             dell.DellNos.ADD_NETWORK,
             segmentation_id=22,
-            network_id=22)
-        self.assertEqual(cmd_set, ['interface vlan 22', 'name 22', 'exit'])
+            network_id=22,
+            network_name='vlan-22')
+        self.assertEqual(cmd_set,
+                         ['interface vlan 22', 'name vlan-22', 'exit'])
 
         cmd_set = self.switch._format_commands(
             dell.DellNos.DELETE_NETWORK,

--- a/networking_generic_switch/tests/unit/netmiko/test_juniper.py
+++ b/networking_generic_switch/tests/unit/netmiko/test_juniper.py
@@ -307,14 +307,16 @@ error: configuration check-out failed
         cmd_set = self.switch._format_commands(
             juniper.Juniper.ADD_NETWORK,
             segmentation_id=22,
-            network_id=22)
-        self.assertEqual(cmd_set, ['set vlans 22 vlan-id 22'])
+            network_id=22,
+            network_name='vlan-22')
+        self.assertEqual(cmd_set, ['set vlans vlan-22 vlan-id 22'])
 
         cmd_set = self.switch._format_commands(
             juniper.Juniper.DELETE_NETWORK,
             segmentation_id=22,
-            network_id=22)
-        self.assertEqual(cmd_set, ['delete vlans 22'])
+            network_id=22,
+            network_name='vlan-22')
+        self.assertEqual(cmd_set, ['delete vlans vlan-22'])
 
         cmd_set = self.switch._format_commands(
             juniper.Juniper.PLUG_PORT_TO_NETWORK,

--- a/networking_generic_switch/tests/unit/test_generic_switch_mech.py
+++ b/networking_generic_switch/tests/unit/test_generic_switch_mech.py
@@ -128,8 +128,9 @@ class TestGenericSwitchDriver(unittest.TestCase):
 
         self.assertRaisesRegexp(ValueError, "boom",
                                 driver.create_network_postcommit, mock_context)
-        self.switch_mock.add_network.assert_called_once_with(22, 22)
-        self.assertEqual(1, m_log.error.call_count)
+        self.switch_mock.add_network.assert_called_with(22, 22)
+        self.assertEqual(2, self.switch_mock.add_network.call_count)
+        self.assertEqual(2, m_log.error.call_count)
         self.assertIn('Failed to create network', m_log.error.call_args[0][0])
 
     def test_delete_network_postcommit(self, m_list):

--- a/releasenotes/notes/network-name-format-075f5757d599ac92.yaml
+++ b/releasenotes/notes/network-name-format-075f5757d599ac92.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Adds support for configuring the format of the name assigned to VLANs in
+    device configuration via the ``ngs_network_name_format`` device
+    configuration option.

--- a/releasenotes/notes/parallelise-net-create-delete-9dedbbca1a0bff47.yaml
+++ b/releasenotes/notes/parallelise-net-create-delete-9dedbbca1a0bff47.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    Adds support for parallel creation and deletion of networks. This can be
+    useful when there are many devices configured and device configuration
+    takes a long time to complete. The number of threads available to perform
+    this work is configured via the configuration option
+    ``[ngs_threadpool]size``, and defaults to 100.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@
 # process, which may cause wedges in the gate later.
 stevedore>=1.20.0 # Apache-2.0
 netmiko>=2.4.1 # MIT
-neutron>=13.0.0.0b1 # Apache-2.0
 neutron-lib>=1.18.0 # Apache-2.0
 oslo.config>=5.2.0 # Apache-2.0
 oslo.i18n>=3.15.3 # Apache-2.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -17,3 +17,5 @@ doc8>=0.6.0 # Apache-2.0
 
 # Tempest plugin requirements
 futurist>=1.2.0 # Apache-2.0
+
+neutron>=13.0.0.0b1,<14 # Apache-2.0


### PR DESCRIPTION
Patches on stein:
```
pick 13922fa Add a TravisCI configuration file to test downstream changes
pick 42a936a Remove neutron from requirements
pick ae37629 Retry junos operations on harmless warnings
pick 2dd343e Remove transitional single argument del_network support
pick c03fc70 Fail if creation or deletion of a network on a device fails
pick 79f1509 Allow network name format to be configured
pick 141cac4 Create and delete networks in parallel
```
Removing anything that is already in train, leaves:
```
pick 13922fa Add a TravisCI configuration file to test downstream changes
pick 42a936a Remove neutron from requirements
pick 79f1509 Allow network name format to be configured
pick 141cac4 Create and delete networks in parallel
```