### PR TITLE
Use train upper constraints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ env:
     # Build documentation.
     - TOX_ENV=docs
     # Run python2.7 unit tests.
-    - TOX_ENV=py27
+    - TOX_ENV=py27 UPPER_CONSTRAINTS_FILE=https://releases.openstack.org/constraints/upper/train
 
 install:
   # Install tox in a virtualenv to ensure we have an up to date version.


### PR DESCRIPTION
Travis builds were failing due to the use of f-strings:

```
  File "/home/travis/build/stackhpc/networking-generic-switch/.tox/py27/lib/python2.7/site-packages/netmiko/cisco_base_connection.py", line 143
    msg = f"Login failed: {self.host}"
                                     ^
SyntaxError: invalid syntax
```

Change-Id: Ie1cc8e8470a86f4692a0530443d362c5cd139c7a