### PR TITLE
Fix stable/train CI

### DIFF
--- a/.gitreview
+++ b/.gitreview
@@ -2,3 +2,4 @@
 host=review.opendev.org
 port=29418
 project=openstack/networking-generic-switch.git
+defaultbranch=stable/train

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ setenv = VIRTUAL_ENV={envdir}
          LC_ALL=en_US.UTF-8
          TESTS_DIR=./networking_generic_switch/tests/unit/
 deps =
-    -c{env:UPPER_CONSTRAINTS_FILE:https://opendev.org/openstack/requirements/raw/branch/master/upper-constraints.txt}
+    -c{env:UPPER_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/train}
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/test-requirements.txt
 passenv = http_proxy HTTP_PROXY https_proxy HTTPS_PROXY no_proxy NO_PROXY
@@ -36,7 +36,7 @@ setenv = PYTHONHASHSEED=0
 sitepackages = False
 envdir = {toxworkdir}/venv
 deps =
-    -c{env:UPPER_CONSTRAINTS_FILE:https://opendev.org/openstack/requirements/raw/branch/master/upper-constraints.txt}
+    -c{env:UPPER_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/train}
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/doc/requirements.txt
 commands =
@@ -56,7 +56,7 @@ commands =
 [testenv:releasenotes]
 basepython = python3
 deps =
-    -c{env:UPPER_CONSTRAINTS_FILE:https://opendev.org/openstack/requirements/raw/branch/master/upper-constraints.txt}
+    -c{env:UPPER_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/train}
     -r{toxinidir}/doc/requirements.txt
 commands =
   sphinx-build -a -E -W -d releasenotes/build/doctrees -b html releasenotes/source releasenotes/build/html
@@ -65,7 +65,7 @@ commands =
 basepython = python3
 setenv = PYTHONHASHSEED=0
 deps =
-    -c{env:UPPER_CONSTRAINTS_FILE:https://opendev.org/openstack/requirements/raw/branch/master/upper-constraints.txt}
+    -c{env:UPPER_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/train}
     -r{toxinidir}/test-requirements.txt
     -r{toxinidir}/doc/requirements.txt
 commands = {posargs}

--- a/zuul.d/networking-generic-switch-jobs.yaml
+++ b/zuul.d/networking-generic-switch-jobs.yaml
@@ -72,5 +72,6 @@
     name: networking-generic-switch-tempest-dlm-python2
     parent: networking-generic-switch-tempest-dlm-base
     vars:
+      tox_envlist: py27
       devstack_localrc:
         USE_PYTHON3: False

--- a/zuul.d/project.yaml
+++ b/zuul.d/project.yaml
@@ -13,7 +13,9 @@
             irrelevant-files:
               - ^(test-|)requirements.txt$
               - ^setup.cfg$
-        - ironic-grenade-dsvm-multinode-multitenant
+        # NOTE(iurygregory): Non-voting due to instability.
+        - ironic-grenade-dsvm-multinode-multitenant:
+            voting: false
         - openstack-tox-lower-constraints
     gate:
       queue: networking-generic-switch
@@ -24,5 +26,6 @@
             irrelevant-files:
               - ^(test-|)requirements.txt$
               - ^setup.cfg$
-        - ironic-grenade-dsvm-multinode-multitenant
+        # Removing from gate due to instability.
+        # - ironic-grenade-dsvm-multinode-multitenant
         - openstack-tox-lower-constraints


### PR DESCRIPTION
This change fixes the stable/train CI for ngs

- update the .gitreview
- update tox.ini
- Change ironic-grenade-dsvm-multinode-multitenant to non-voting.
- Fix tempest for networking-generic-switch-tempest-dlm-python2.

Change-Id: Ibb6735c6f03513630cd02e0cf273e0d0e5dc4d0a