### PR TITLE
yoga cherries

### DIFF
--- a/networking_generic_switch/devices/__init__.py
+++ b/networking_generic_switch/devices/__init__.py
@@ -151,3 +151,11 @@ class GenericSwitchDevice(object, metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def delete_port(self, port_id, segmentation_id):
         pass
+
+    def plug_bond_to_network(self, bond_id, segmentation_id):
+        # Fall back to interface method.
+        return self.plug_port_to_network(bond_id, segmentation_id)
+
+    def unplug_bond_from_network(self, bond_id, segmentation_id):
+        # Fall back to interface method.
+        return self.delete_port(bond_id, segmentation_id)

--- a/networking_generic_switch/devices/netmiko_devices/cumulus.py
+++ b/networking_generic_switch/devices/netmiko_devices/cumulus.py
@@ -51,12 +51,28 @@ class Cumulus(netmiko_devices.NetmikoSwitch):
         'net del interface {port} bridge access {segmentation_id}',
     ]
 
+    PLUG_BOND_TO_NETWORK = [
+        'net add bond {bond} bridge access {segmentation_id}',
+    ]
+
+    UNPLUG_BOND_FROM_NETWORK = [
+        'net del bond {bond} bridge access {segmentation_id}',
+    ]
+
     ENABLE_PORT = [
         'net del interface {port} link down',
     ]
 
     DISABLE_PORT = [
         'net add interface {port} link down',
+    ]
+
+    ENABLE_BOND = [
+        'net del bond {bond} link down',
+    ]
+
+    DISABLE_BOND = [
+        'net add bond {bond} link down',
     ]
 
     SAVE_CONFIGURATION = [

--- a/networking_generic_switch/tests/unit/netmiko/test_cumulus.py
+++ b/networking_generic_switch/tests/unit/netmiko/test_cumulus.py
@@ -110,6 +110,51 @@ class TestNetmikoCumulus(test_netmiko_base.NetmikoSwitchTestBase):
         mock_exec.assert_called_with(
             ['net del interface 3333 bridge access 33'])
 
+    @mock.patch('networking_generic_switch.devices.netmiko_devices.'
+                'NetmikoSwitch.send_commands_to_device',
+                return_value="")
+    def test_plug_bond_to_network(self, mock_exec):
+        self.switch.plug_bond_to_network(3333, 33)
+        mock_exec.assert_called_with(
+            ['net del bond 3333 link down',
+             'net del bond 3333 bridge access 123',
+             'net add bond 3333 bridge access 33'])
+
+    @mock.patch('networking_generic_switch.devices.netmiko_devices.'
+                'NetmikoSwitch.send_commands_to_device',
+                return_value="")
+    def test_plug_bond_simple(self, mock_exec):
+        switch = self._make_switch_device({
+            'ngs_disable_inactive_ports': 'false',
+            'ngs_port_default_vlan': '',
+        })
+        switch.plug_bond_to_network(3333, 33)
+        mock_exec.assert_called_with(
+            ['net add bond 3333 bridge access 33'])
+
+    @mock.patch('networking_generic_switch.devices.netmiko_devices.'
+                'NetmikoSwitch.send_commands_to_device',
+                return_value="")
+    def test_unplug_bond_from_network(self, mock_exec):
+        self.switch.unplug_bond_from_network(3333, 33)
+        mock_exec.assert_called_with(
+            ['net del bond 3333 bridge access 33',
+             'net add vlan 123',
+             'net add bond 3333 bridge access 123',
+             'net add bond 3333 link down'])
+
+    @mock.patch('networking_generic_switch.devices.netmiko_devices.'
+                'NetmikoSwitch.send_commands_to_device',
+                return_value="")
+    def test_unplug_bond_from_network_simple(self, mock_exec):
+        switch = self._make_switch_device({
+            'ngs_disable_inactive_ports': 'false',
+            'ngs_port_default_vlan': '',
+        })
+        switch.unplug_bond_from_network(3333, 33)
+        mock_exec.assert_called_with(
+            ['net del bond 3333 bridge access 33'])
+
     def test_save(self):
         mock_connect = mock.MagicMock()
         mock_connect.save_config.side_effect = NotImplementedError

--- a/networking_generic_switch/tests/unit/test_devices.py
+++ b/networking_generic_switch/tests/unit/test_devices.py
@@ -57,6 +57,18 @@ class TestGenericSwitchDevice(unittest.TestCase):
             self.assertIn(m, ex.exception.args[0])
         self.assertIsNone(device)
 
+    @mock.patch.object(FakeDevice, 'plug_port_to_network')
+    def test_plug_bond_to_network_fallback(self, mock_plug):
+        device = FakeDevice({'spam': 'ham'})
+        device.plug_bond_to_network(22, 33)
+        mock_plug.assert_called_once_with(22, 33)
+
+    @mock.patch.object(FakeDevice, 'delete_port')
+    def test_unplug_bond_from_network_fallback(self, mock_delete):
+        device = FakeDevice({'spam': 'ham'})
+        device.unplug_bond_from_network(22, 33)
+        mock_delete.assert_called_once_with(22, 33)
+
 
 class TestDeviceManager(unittest.TestCase):
 

--- a/networking_generic_switch/tests/unit/test_generic_switch_mech.py
+++ b/networking_generic_switch/tests/unit/test_generic_switch_mech.py
@@ -280,6 +280,40 @@ class TestGenericSwitchDriver(unittest.TestCase):
             [mock.call(2222, 123),
              mock.call(3333, 123)])
 
+    def test_delete_portgroup_postcommit_802_3ad(self, m_list):
+        driver = gsm.GenericSwitchDriver()
+        driver.initialize()
+        mock_context = mock.create_autospec(driver_context.PortContext)
+        mock_context.current = {'binding:profile':
+                                {'local_link_information':
+                                    [
+                                        {
+                                            'switch_info': 'foo',
+                                            'port_id': 2222
+                                        },
+                                        {
+                                            'switch_info': 'foo',
+                                            'port_id': 3333
+                                        },
+                                    ],
+                                 'local_group_information':
+                                    {
+                                        'bond_mode': '4'
+                                    }
+                                 },
+                                'binding:vnic_type': 'baremetal',
+                                'binding:vif_type': 'other',
+                                'id': 'aaaa-bbbb-cccc'}
+        mock_context.network = mock.Mock()
+        mock_context.network.current = {'provider:segmentation_id': 123,
+                                        'id': 'aaaa-bbbb-cccc'}
+        mock_context.segments_to_bind = [mock_context.network.current]
+
+        driver.delete_port_postcommit(mock_context)
+        self.switch_mock.unplug_bond_from_network.assert_has_calls(
+            [mock.call(2222, 123),
+             mock.call(3333, 123)])
+
     def test_delete_port_postcommit_failure(self, m_list):
         driver = gsm.GenericSwitchDriver()
         driver.initialize()
@@ -508,6 +542,45 @@ class TestGenericSwitchDriver(unittest.TestCase):
                                  'binding:vif_type': 'unbound'}
         driver.update_port_postcommit(mock_context)
         self.switch_mock.plug_port_to_network.assert_not_called()
+        m_pc.assert_has_calls([mock.call(mock_context._plugin_context,
+                                         mock_context.current['id'],
+                                         resources.PORT,
+                                         'GENERICSWITCH')])
+
+    @mock.patch.object(provisioning_blocks, 'provisioning_complete')
+    def test_update_portgroup_postcommit_complete_provisioning_802_3ad(self,
+                                                                       m_pc,
+                                                                       m_list):
+        driver = gsm.GenericSwitchDriver()
+        driver.initialize()
+        mock_context = mock.create_autospec(driver_context.PortContext)
+        mock_context._plugin_context = mock.MagicMock()
+        mock_context.current = {'binding:profile':
+                                {'local_link_information':
+                                    [
+                                        {
+                                            'switch_info': 'foo',
+                                            'port_id': 2222
+                                        },
+                                        {
+                                            'switch_info': 'foo',
+                                            'port_id': 3333
+                                        },
+                                    ],
+                                 'local_group_information':
+                                    {
+                                        'bond_mode': '802.3ad'
+                                    }
+                                 },
+                                'binding:vnic_type': 'baremetal',
+                                'id': '123',
+                                'binding:vif_type': 'other'}
+        mock_context.original = {'binding:profile': {},
+                                 'binding:vnic_type': 'baremetal',
+                                 'id': '123',
+                                 'binding:vif_type': 'unbound'}
+        driver.update_port_postcommit(mock_context)
+        self.switch_mock.plug_bond_to_network.assert_not_called()
         m_pc.assert_has_calls([mock.call(mock_context._plugin_context,
                                          mock_context.current['id'],
                                          resources.PORT,
@@ -755,6 +828,54 @@ class TestGenericSwitchDriver(unittest.TestCase):
                                           'GENERICSWITCH')])
 
     @mock.patch.object(provisioning_blocks, 'add_provisioning_component')
+    def test_bind_portgroup_802_3ad(self, m_apc, m_list):
+        driver = gsm.GenericSwitchDriver()
+        driver.initialize()
+        mock_context = mock.create_autospec(driver_context.PortContext)
+        mock_context._plugin_context = mock.MagicMock()
+        mock_context.current = {'binding:profile':
+                                {'local_link_information':
+                                    [
+                                        {
+                                            'switch_info': 'foo',
+                                            'port_id': 2222
+                                        },
+                                        {
+                                            'switch_info': 'foo',
+                                            'port_id': 3333
+                                        },
+                                    ],
+                                 'local_group_information':
+                                    {
+                                        'bond_mode': '802.3ad'
+                                    }
+                                 },
+                                'binding:vnic_type': 'baremetal',
+                                'id': '123'}
+        mock_context.network.current = {
+            'provider:physical_network': 'physnet1'
+        }
+        mock_context.segments_to_bind = [
+            {
+                'segmentation_id': None,
+                'id': 123
+            }
+        ]
+
+        driver.bind_port(mock_context)
+        self.switch_mock.plug_bond_to_network.assert_has_calls(
+            [mock.call(2222, 1),
+             mock.call(3333, 1)]
+        )
+        mock_context.set_binding.assert_has_calls(
+            [mock.call(123, 'other', {})]
+        )
+        m_apc.assert_has_calls([mock.call(mock_context._plugin_context,
+                                          mock_context.current['id'],
+                                          resources.PORT,
+                                          'GENERICSWITCH')])
+
+    @mock.patch.object(provisioning_blocks, 'add_provisioning_component')
     def test_bind_port_with_physnet(self, m_apc, m_list):
         driver = gsm.GenericSwitchDriver()
         driver.initialize()
@@ -878,3 +999,34 @@ class TestGenericSwitchDriver(unittest.TestCase):
         driver.create_port_postcommit(mock_context)
         driver.update_port_precommit(mock_context)
         driver.delete_port_precommit(mock_context)
+
+
+class TestGenericSwitchDriverStaticMethods(unittest.TestCase):
+
+    def test__is_802_3ad_no_lgi(self):
+        driver = gsm.GenericSwitchDriver()
+        port = {'binding:profile': {}}
+        self.assertFalse(driver._is_802_3ad(port))
+
+    def test__is_802_3ad_no_bond_mode(self):
+        driver = gsm.GenericSwitchDriver()
+        port = {'binding:profile': {'local_group_information': {}}}
+        self.assertFalse(driver._is_802_3ad(port))
+
+    def test__is_802_3ad_wrong_bond_mode(self):
+        driver = gsm.GenericSwitchDriver()
+        port = {'binding:profile': {'local_group_information':
+                {'bond_mode': 42}}}
+        self.assertFalse(driver._is_802_3ad(port))
+
+    def test__is_802_3ad_numeric(self):
+        driver = gsm.GenericSwitchDriver()
+        port = {'binding:profile': {'local_group_information':
+                {'bond_mode': '4'}}}
+        self.assertTrue(driver._is_802_3ad(port))
+
+    def test__is_802_3ad_string(self):
+        driver = gsm.GenericSwitchDriver()
+        port = {'binding:profile': {'local_group_information':
+                {'bond_mode': '802.3ad'}}}
+        self.assertTrue(driver._is_802_3ad(port))

--- a/releasenotes/notes/cumulus-802.3ad-da9bffe131995f98.yaml
+++ b/releasenotes/notes/cumulus-802.3ad-da9bffe131995f98.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Adds support for 802.3ad port groups on NVIDIA Cumulus devices.


### PR DESCRIPTION
[xena] 88df4c73fa None feat: automatic update of community files stackhpc/xena

  SKIP: created by stackhpc-ci bot

[xena] 50c1f43b08 None feat: automatic update of workflows stackhpc/xena

  SKIP: created by stackhpc-ci bot

[xena] 354c99ed4c I0693c495170aa821a2f571038f387c50a2f6c599 Support 802.3ad port groups on Cumulus devices

  CHOICE: present on multiple branches

    [master] aea6708044

[xena] 3dfae10a87 Ic3e10d19315b776662188f41c552fe0676a12782 Support multiple links in link_local_information dict of portgroups

  SKIP: present on yoga

[xena] 7b7b04a838 I271263a349d6cccd0fe9980e10b1b8d5fd86716e Add ngs_manage_vlans configuration

  SKIP: present on yoga
