### PR TITLE
Add support for Dell OS10

### DIFF
--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -92,6 +92,16 @@ for the Dell Force10 device::
     password = password
     secret = secret
 
+for the Dell OS10 device::
+
+    [genericswitch:dell-hostname]
+    device_type = netmiko_dell_os10
+    ngs_mac_address = <switch mac address>
+    ip = <switch mgmt ip address>
+    username = admin
+    password = password
+    secret = secret
+
 for the Dell PowerConnect device::
 
     [genericswitch:dell-hostname]

--- a/doc/source/supported-devices.rst
+++ b/doc/source/supported-devices.rst
@@ -10,6 +10,7 @@ The following devices are supported by this plugin:
 * Cisco IOS switches
 * Cumulus Linux (via NCLU)
 * Dell Force10
+* Dell OS10
 * Dell PowerConnect
 * HPE 5900 Series switches
 * Huawei switches

--- a/networking_generic_switch/devices/netmiko_devices/dell.py
+++ b/networking_generic_switch/devices/netmiko_devices/dell.py
@@ -23,6 +23,7 @@ class DellOS10(netmiko_devices.NetmikoSwitch):
 
     ADD_NETWORK = (
         "interface vlan {segmentation_id}",
+        "description {network_name}",
         "exit",
     )
 

--- a/networking_generic_switch/tests/unit/netmiko/test_dell.py
+++ b/networking_generic_switch/tests/unit/netmiko/test_dell.py
@@ -238,6 +238,43 @@ class TestNetmikoDellOS10(test_netmiko_base.NetmikoSwitchTestBase):
                           'no switchport trunk allowed vlan 33',
                           'exit'])
 
+    def test_get_trunk_port_cmds_no_vlan_translation(self):
+        mock_context = mock.create_autospec(driver_context.PortContext)
+        self.switch.ngs_config['vlan_translation_supported'] = True
+        trunk_details = {'trunk_id': 'aaa-bbb-ccc-ddd',
+                         'sub_ports': [{'segmentation_id': 130,
+                                        'port_id': 'aaa-bbb-ccc-ddd',
+                                        'segmentation_type': 'vlan',
+                                        'mac_address': u'fa:16:3e:1c:c2:7e'}]}
+        mock_context.current = {'binding:profile':
+                                {'local_link_information':
+                                    [
+                                        {
+                                            'switch_info': 'foo',
+                                            'port_id': '2222'
+                                        }
+                                    ]
+                                 },
+                                'binding:vnic_type': 'baremetal',
+                                'id': 'aaaa-bbbb-cccc',
+                                'trunk_details': trunk_details}
+        mock_context.network = mock.Mock()
+        mock_context.network.current = {'provider:segmentation_id': 123}
+        mock_context.segments_to_bind = [
+            {
+                'segmentation_id': 777,
+                'id': 123
+            }
+        ]
+        res = self.switch.get_trunk_port_cmds_no_vlan_translation(
+            '2222', 777, trunk_details)
+        self.assertEqual(['interface 2222', 'switchport mode access',
+                          'switchport mode trunk',
+                          'switchport access vlan 777',
+                          'interface 2222',
+                          'switchport trunk allowed vlan 130'],
+                         res)
+
 
 class TestNetmikoDellPowerConnect(test_netmiko_base.NetmikoSwitchTestBase):
 

--- a/networking_generic_switch/tests/unit/netmiko/test_dell.py
+++ b/networking_generic_switch/tests/unit/netmiko/test_dell.py
@@ -21,51 +21,6 @@ from networking_generic_switch import exceptions as exc
 from networking_generic_switch.tests.unit.netmiko import test_netmiko_base
 
 
-class TestNetmikoDellOS10(test_netmiko_base.NetmikoSwitchTestBase):
-
-    def _make_switch_device(self, extra_cfg={}):
-        device_cfg = {'device_type': 'netmiko_dell_os10'}
-        device_cfg.update(extra_cfg)
-        return dell.DellOS10(device_cfg)
-
-    def test_get_trunk_port_cmds_no_vlan_translation(self):
-        mock_context = mock.create_autospec(driver_context.PortContext)
-        self.switch.ngs_config['vlan_translation_supported'] = True
-        trunk_details = {'trunk_id': 'aaa-bbb-ccc-ddd',
-                         'sub_ports': [{'segmentation_id': 130,
-                                        'port_id': 'aaa-bbb-ccc-ddd',
-                                        'segmentation_type': 'vlan',
-                                        'mac_address': u'fa:16:3e:1c:c2:7e'}]}
-        mock_context.current = {'binding:profile':
-                                {'local_link_information':
-                                    [
-                                        {
-                                            'switch_info': 'foo',
-                                            'port_id': '2222'
-                                        }
-                                    ]
-                                 },
-                                'binding:vnic_type': 'baremetal',
-                                'id': 'aaaa-bbbb-cccc',
-                                'trunk_details': trunk_details}
-        mock_context.network = mock.Mock()
-        mock_context.network.current = {'provider:segmentation_id': 123}
-        mock_context.segments_to_bind = [
-            {
-                'segmentation_id': 777,
-                'id': 123
-            }
-        ]
-        res = self.switch.get_trunk_port_cmds_no_vlan_translation(
-            '2222', 777, trunk_details)
-        self.assertEqual(['interface 2222', 'switchport mode access',
-                          'switchport mode trunk',
-                          'switchport access vlan 777',
-                          'interface 2222',
-                          'switchport trunk allowed vlan 130'],
-                         res)
-
-
 class TestNetmikoDellNos(test_netmiko_base.NetmikoSwitchTestBase):
 
     def _make_switch_device(self, extra_cfg={}):
@@ -164,6 +119,124 @@ class TestNetmikoDellNos(test_netmiko_base.NetmikoSwitchTestBase):
             segmentation_id=33)
         self.assertEqual(cmd_set,
                          ['interface vlan 33', 'no tagged 3333', 'exit'])
+
+
+class TestNetmikoDellOS10(test_netmiko_base.NetmikoSwitchTestBase):
+
+    def _make_switch_device(self, extra_cfg={}):
+        device_cfg = {'device_type': 'netmiko_dell_os10'}
+        device_cfg.update(extra_cfg)
+        return dell.DellOS10(device_cfg)
+
+    def test_constants(self):
+        self.assertIsNone(self.switch.SAVE_CONFIGURATION)
+
+    @mock.patch('networking_generic_switch.devices.netmiko_devices.'
+                'NetmikoSwitch.send_commands_to_device')
+    def test_add_network(self, m_exec):
+        self.switch.add_network(33, '0ae071f5-5be9-43e4-80ea-e41fefe85b21')
+        m_exec.assert_called_with(
+            ['interface vlan 33',
+             'description 0ae071f55be943e480eae41fefe85b21',
+             'exit']
+        )
+
+    @mock.patch('networking_generic_switch.devices.netmiko_devices.'
+                'NetmikoSwitch.send_commands_to_device')
+    def test_add_network_with_trunk_ports(self, mock_exec):
+        switch = self._make_switch_device({'ngs_trunk_ports': 'port1, port2'})
+        switch.add_network(33, '0ae071f5-5be9-43e4-80ea-e41fefe85b21')
+        mock_exec.assert_called_with(
+            ['interface vlan 33',
+             'description 0ae071f55be943e480eae41fefe85b21',
+             'exit',
+             'interface port1', 'switchport mode trunk',
+             'switchport trunk allowed vlan 33', 'exit',
+             'interface port2', 'switchport mode trunk',
+             'switchport trunk allowed vlan 33', 'exit']
+        )
+
+    @mock.patch('networking_generic_switch.devices.netmiko_devices.'
+                'NetmikoSwitch.send_commands_to_device')
+    def test_del_network(self, mock_exec):
+        self.switch.del_network(33, '0ae071f5-5be9-43e4-80ea-e41fefe85b21')
+        mock_exec.assert_called_with(['no interface vlan 33', 'exit'])
+
+    @mock.patch('networking_generic_switch.devices.netmiko_devices.'
+                'NetmikoSwitch.send_commands_to_device')
+    def test_del_network_with_trunk_ports(self, mock_exec):
+        switch = self._make_switch_device({'ngs_trunk_ports': 'port1, port2'})
+        switch.del_network(33, '0ae071f55be943e480eae41fefe85b21')
+        mock_exec.assert_called_with(
+            ['interface port1', 'no switchport trunk allowed vlan 33', 'exit',
+             'interface port2', 'no switchport trunk allowed vlan 33', 'exit',
+             'no interface vlan 33', 'exit'])
+
+    @mock.patch('networking_generic_switch.devices.netmiko_devices.'
+                'NetmikoSwitch.send_commands_to_device')
+    def test_plug_port_to_network(self, mock_exec):
+        self.switch.plug_port_to_network(3333, 33)
+        mock_exec.assert_called_with(
+            ['interface 3333', 'switchport mode access',
+             'switchport access vlan 33',
+             'exit']
+        )
+
+    @mock.patch('networking_generic_switch.devices.netmiko_devices.'
+                'NetmikoSwitch.send_commands_to_device')
+    def test_delete_port(self, mock_exec):
+        self.switch.delete_port(3333, 33)
+        mock_exec.assert_called_with(
+            ['interface 3333', 'no switchport access vlan', 'exit']
+        )
+
+    def test__format_commands(self):
+        cmd_set = self.switch._format_commands(
+            dell.DellOS10.ADD_NETWORK,
+            segmentation_id=22,
+            network_id=22,
+            network_name='vlan-22')
+        self.assertEqual(cmd_set,
+                         ['interface vlan 22',
+                          'description vlan-22',
+                          'exit']
+                         )
+
+        cmd_set = self.switch._format_commands(
+            dell.DellOS10.DELETE_NETWORK,
+            segmentation_id=22)
+        self.assertEqual(cmd_set, ['no interface vlan 22', 'exit'])
+
+        cmd_set = self.switch._format_commands(
+            dell.DellOS10.PLUG_PORT_TO_NETWORK,
+            port=3333,
+            segmentation_id=33)
+        self.assertEqual(cmd_set, ['interface 3333', 'switchport mode access',
+                                   'switchport access vlan 33', 'exit'])
+        cmd_set = self.switch._format_commands(
+            dell.DellOS10.DELETE_PORT,
+            port=3333,
+            segmentation_id=33)
+        self.assertEqual(cmd_set,
+                         ['interface 3333', 'no switchport access vlan',
+                          'exit'])
+
+        cmd_set = self.switch._format_commands(
+            dell.DellOS10.ADD_NETWORK_TO_TRUNK,
+            port=3333,
+            segmentation_id=33)
+        self.assertEqual(cmd_set,
+                         ['interface 3333', 'switchport mode trunk',
+                          'switchport trunk allowed vlan 33',
+                          'exit'])
+        cmd_set = self.switch._format_commands(
+            dell.DellOS10.REMOVE_NETWORK_FROM_TRUNK,
+            port=3333,
+            segmentation_id=33)
+        self.assertEqual(cmd_set,
+                         ['interface 3333',
+                          'no switchport trunk allowed vlan 33',
+                          'exit'])
 
 
 class TestNetmikoDellPowerConnect(test_netmiko_base.NetmikoSwitchTestBase):

--- a/networking_generic_switch/tests/unit/netmiko/test_dell.py
+++ b/networking_generic_switch/tests/unit/netmiko/test_dell.py
@@ -144,7 +144,7 @@ class TestNetmikoDellOS10(test_netmiko_base.NetmikoSwitchTestBase):
     @mock.patch('networking_generic_switch.devices.netmiko_devices.'
                 'NetmikoSwitch.send_commands_to_device')
     def test_add_network_with_trunk_ports(self, mock_exec):
-        switch = self._make_switch_device({'ngs_trunk_ports': 'port1, port2'})
+        switch = self._make_switch_device({'ngs_trunk_ports': 'port1,port2'})
         switch.add_network(33, '0ae071f5-5be9-43e4-80ea-e41fefe85b21')
         mock_exec.assert_called_with(
             ['interface vlan 33',
@@ -165,7 +165,7 @@ class TestNetmikoDellOS10(test_netmiko_base.NetmikoSwitchTestBase):
     @mock.patch('networking_generic_switch.devices.netmiko_devices.'
                 'NetmikoSwitch.send_commands_to_device')
     def test_del_network_with_trunk_ports(self, mock_exec):
-        switch = self._make_switch_device({'ngs_trunk_ports': 'port1, port2'})
+        switch = self._make_switch_device({'ngs_trunk_ports': 'port1,port2'})
         switch.del_network(33, '0ae071f55be943e480eae41fefe85b21')
         mock_exec.assert_called_with(
             ['interface port1', 'no switchport trunk allowed vlan 33', 'exit',

--- a/releasenotes/notes/add-dellos10-support-c6426372f960ded4.yaml
+++ b/releasenotes/notes/add-dellos10-support-c6426372f960ded4.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Adds a new device driver, ``netmiko_dell_os10``, for managing Dell OS10
+    based switch devices.

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ generic_switch.devices =
     netmiko_huawei = networking_generic_switch.devices.netmiko_devices.huawei:Huawei
     netmiko_huawei_vrpv8 = networking_generic_switch.devices.netmiko_devices.huawei_vrpv8:Huawei
     netmiko_arista_eos = networking_generic_switch.devices.netmiko_devices.arista:AristaEos
+    netmiko_dell_os10 = networking_generic_switch.devices.netmiko_devices.dell:DellOS10
     netmiko_dell_force10 = networking_generic_switch.devices.netmiko_devices.dell:DellNos
     netmiko_dell_powerconnect = networking_generic_switch.devices.netmiko_devices.dell:DellPowerConnect
     netmiko_brocade_fastiron = networking_generic_switch.devices.netmiko_devices.brocade:BrocadeFastIron


### PR DESCRIPTION
This adds a new driver for Dell OS10 based switches.
Original change by msherman64[1].

[1] https://github.com/ChameleonCloud/networking-generic-switch/pull/14

Change-Id: Ib5bba3067352e6c7e12120982fcf5b206c9dd365
(cherry picked from commit 0ecd02aaa036311c67671717562db956bbc810aa)
