### PR TITLE
Fix regression plugging 802.3ad port group

### DIFF
--- a/networking_generic_switch/devices/netmiko_devices/__init__.py
+++ b/networking_generic_switch/devices/netmiko_devices/__init__.py
@@ -339,6 +339,10 @@ class NetmikoSwitch(devices.GenericSwitchDevice):
 
     @check_output('plug bond')
     def plug_bond_to_network(self, bond, segmentation_id):
+        # Fallback to regular plug port if no specialist PLUG_BOND_TO_NETWORK
+        # commands set
+        if not self.PLUG_BOND_TO_NETWORK:
+            return self.plug_port_to_network(bond, segmentation_id)
         cmds = []
         if self._disable_inactive_ports() and self.ENABLE_BOND:
             cmds += self._format_commands(self.ENABLE_BOND, bond=bond)
@@ -356,6 +360,10 @@ class NetmikoSwitch(devices.GenericSwitchDevice):
 
     @check_output('unplug bond')
     def unplug_bond_from_network(self, bond, segmentation_id):
+        # Fallback to regular port delete if no specialist
+        # UNPLUG_BOND_FROM_NETWORK commands set
+        if not self.UNPLUG_BOND_FROM_NETWORK:
+            return self.delete_port(bond, segmentation_id)
         cmds = self._format_commands(self.UNPLUG_BOND_FROM_NETWORK,
                                      bond=bond,
                                      segmentation_id=segmentation_id)

--- a/networking_generic_switch/tests/unit/netmiko/test_dell.py
+++ b/networking_generic_switch/tests/unit/netmiko/test_dell.py
@@ -165,6 +165,25 @@ class TestNetmikoDellOS10(test_netmiko_base.NetmikoSwitchTestBase):
         mock_exec.assert_called_with(['no interface vlan 33', 'exit'])
 
     @mock.patch('networking_generic_switch.devices.netmiko_devices.'
+                'NetmikoSwitch.send_commands_to_device',
+                return_value="")
+    def test_plug_bond_to_network(self, mock_exec):
+        self.switch.plug_bond_to_network(3333, 33)
+        mock_exec.assert_called_with(
+            ['interface 3333', 'switchport mode access',
+             'switchport access vlan 33',
+             'exit']
+        )
+
+    @mock.patch('networking_generic_switch.devices.netmiko_devices.'
+                'NetmikoSwitch.send_commands_to_device')
+    def test_unplug_bond_from_network(self, mock_exec):
+        self.switch.unplug_bond_from_network(3333, 33)
+        mock_exec.assert_called_with(
+            ['interface 3333', 'no switchport access vlan', 'exit']
+        )
+
+    @mock.patch('networking_generic_switch.devices.netmiko_devices.'
                 'NetmikoSwitch.send_commands_to_device')
     def test_del_network_with_trunk_ports(self, mock_exec):
         switch = self._make_switch_device({'ngs_trunk_ports': 'port1,port2'})

--- a/networking_generic_switch/tests/unit/netmiko/test_netmiko_base.py
+++ b/networking_generic_switch/tests/unit/netmiko/test_netmiko_base.py
@@ -187,6 +187,20 @@ class TestNetmikoSwitch(NetmikoSwitchTestBase):
         m_sctd.assert_called_with([])
         m_check.assert_called_once_with('fake output', 'unplug port')
 
+    @mock.patch('networking_generic_switch.devices.netmiko_devices.'
+                'NetmikoSwitch.plug_port_to_network',
+                return_value='fake output')
+    def test_plug_bond_to_network_fallback(self, m_plug):
+        self.switch.plug_bond_to_network(2222, 22)
+        m_plug.assert_called_with(2222, 22)
+
+    @mock.patch('networking_generic_switch.devices.netmiko_devices.'
+                'NetmikoSwitch.delete_port',
+                return_value='fake output')
+    def test_unplug_bond_from_network_fallback(self, m_delete):
+        self.switch.unplug_bond_from_network(2222, 22)
+        m_delete.assert_called_with(2222, 22)
+
     def test__format_commands(self):
         self.switch._format_commands(
             netmiko_devices.NetmikoSwitch.ADD_NETWORK,

--- a/releasenotes/notes/fixes-netmiko-regression-binding-port-groups-af6978a199a381b1.yaml
+++ b/releasenotes/notes/fixes-netmiko-regression-binding-port-groups-af6978a199a381b1.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes a regression when binding 802.3ad port groups on netmiko devices
+    other than cumulus.


### PR DESCRIPTION
Netmiko devices were sending no commands to the switch since plug_bond_to_network is overridden in
networking_generic_switch/devices/netmiko_devices/__init__.py and PLUG_BOND_TO_NETWORK to set to None.

Closes-Bug: #2041516
Change-Id: I27425c2fc0318688f730a4e84816bcfc7e901b51 (cherry picked from commit 40399f27ad471cbf60954d56f0e8114052d1a45f)