### PR TITLE
Add vlan aware VMs support (backport nvue)

### DIFF
--- a/networking_generic_switch/devices/netmiko_devices/cumulus.py
+++ b/networking_generic_switch/devices/netmiko_devices/cumulus.py
@@ -117,6 +117,8 @@ class CumulusNVUE(netmiko_devices.NetmikoSwitch):
     ]
 
     PLUG_PORT_TO_NETWORK = [
+        'nv unset interface {port} bridge domain br_default vlan',
+        'nv unset interface {port} bridge domain br_default untagged',
         'nv set interface {port} bridge domain br_default access '
         '{segmentation_id}',
     ]
@@ -135,6 +137,18 @@ class CumulusNVUE(netmiko_devices.NetmikoSwitch):
 
     SAVE_CONFIGURATION = [
         'nv config save',
+    ]
+
+    SET_NATIVE_VLAN = [
+        'nv unset interface {port} bridge domain br_default access',
+        'nv set interface {port} bridge domain br_default untagged '
+        '{segmentation_id}',
+        'nv set interface {port} bridge domain br_default vlan '
+        '{segmentation_id}'
+    ]
+    ALLOW_NETWORK_ON_TRUNK = [
+        'nv set interface {port} bridge domain br_default vlan '
+        '{segmentation_id}'
     ]
 
     ERROR_MSG_PATTERNS = [

--- a/networking_generic_switch/tests/unit/netmiko/test_cumulus_nvue.py
+++ b/networking_generic_switch/tests/unit/netmiko/test_cumulus_nvue.py
@@ -54,6 +54,8 @@ class TestNetmikoCumulusNVUE(test_netmiko_base.NetmikoSwitchTestBase):
         mock_exec.assert_called_with(
             ['nv set interface 3333 link state up',
              'nv unset interface 3333 bridge domain br_default access',
+             'nv unset interface 3333 bridge domain br_default vlan',
+             'nv unset interface 3333 bridge domain br_default untagged',
              'nv set interface 3333 bridge domain br_default access 33'])
 
     @mock.patch('networking_generic_switch.devices.netmiko_devices.'
@@ -85,7 +87,9 @@ class TestNetmikoCumulusNVUE(test_netmiko_base.NetmikoSwitchTestBase):
         })
         switch.plug_port_to_network(3333, 33)
         mock_exec.assert_called_with(
-            ['nv set interface 3333 bridge domain br_default access 33'])
+            ['nv unset interface 3333 bridge domain br_default vlan',
+             'nv unset interface 3333 bridge domain br_default untagged',
+             'nv set interface 3333 bridge domain br_default access 33'])
 
     @mock.patch('networking_generic_switch.devices.netmiko_devices.'
                 'NetmikoSwitch.send_commands_to_device',
@@ -95,6 +99,8 @@ class TestNetmikoCumulusNVUE(test_netmiko_base.NetmikoSwitchTestBase):
         mock_exec.assert_called_with(
             ['nv unset interface 3333 bridge domain br_default access',
              'nv set bridge domain br_default vlan 123',
+             'nv unset interface 3333 bridge domain br_default vlan',
+             'nv unset interface 3333 bridge domain br_default untagged',
              'nv set interface 3333 bridge domain br_default access 123',
              'nv set interface 3333 link state down'])
 
@@ -118,6 +124,8 @@ class TestNetmikoCumulusNVUE(test_netmiko_base.NetmikoSwitchTestBase):
         mock_exec.assert_called_with(
             ['nv set interface 3333 link state up',
              'nv unset interface 3333 bridge domain br_default access',
+             'nv unset interface 3333 bridge domain br_default vlan',
+             'nv unset interface 3333 bridge domain br_default untagged',
              'nv set interface 3333 bridge domain br_default access 33'])
 
     @mock.patch('networking_generic_switch.devices.netmiko_devices.'
@@ -130,7 +138,9 @@ class TestNetmikoCumulusNVUE(test_netmiko_base.NetmikoSwitchTestBase):
         })
         switch.plug_bond_to_network(3333, 33)
         mock_exec.assert_called_with(
-            ['nv set interface 3333 bridge domain br_default access 33'])
+            ['nv unset interface 3333 bridge domain br_default vlan',
+             'nv unset interface 3333 bridge domain br_default untagged',
+             'nv set interface 3333 bridge domain br_default access 33'])
 
     @mock.patch('networking_generic_switch.devices.netmiko_devices.'
                 'NetmikoSwitch.send_commands_to_device',
@@ -140,6 +150,8 @@ class TestNetmikoCumulusNVUE(test_netmiko_base.NetmikoSwitchTestBase):
         mock_exec.assert_called_with(
             ['nv unset interface 3333 bridge domain br_default access',
              'nv set bridge domain br_default vlan 123',
+             'nv unset interface 3333 bridge domain br_default vlan',
+             'nv unset interface 3333 bridge domain br_default untagged',
              'nv set interface 3333 bridge domain br_default access 123',
              'nv set interface 3333 link state down'])
 


### PR DESCRIPTION
Taken from in-progress patch: https://review.opendev.org/c/openstack/networking-generic-switch/+/928490