### PR TITLE
cumulus_nvue: Don't call enable() and set enter_config_mode = False

### DIFF
--- a/networking_generic_switch/devices/netmiko_devices/cumulus.py
+++ b/networking_generic_switch/devices/netmiko_devices/cumulus.py
@@ -171,9 +171,9 @@ class CumulusNVUE(netmiko_devices.NetmikoSwitch):
         :returns: The output of the configuration commands.
         """
         cmd_set.append('nv config apply --assume-yes')
-        net_connect.enable()
         # NOTE: Do not exit config mode because save needs elevated
         # privileges
         return net_connect.send_config_set(config_commands=cmd_set,
                                            cmd_verify=False,
+                                           enter_config_mode=False,
                                            exit_config_mode=False)


### PR DESCRIPTION
Let's stop using sudo for Cumulus NVUE since that's not needed. It blurs the configuration history with changes applied as root user.

Closes-Bug: #2079916
Change-Id: Id1c8c93a5c0ced2a56bbcf0929c2fb8aea49b09a