### PR TITLE
Switch to upstream trunking support (merged in 2025.1)

### DIFF
--- a/devstack/plugin.sh
+++ b/devstack/plugin.sh
@@ -220,6 +220,7 @@ function ngs_configure_tempest {
     if [ $GENERIC_SWITCH_USER_MAX_SESSIONS -gt 0 ]; then
         iniset $TEMPEST_CONFIG ngs port_dlm_concurrency $(($GENERIC_SWITCH_USER_MAX_SESSIONS * 2))
     fi
+    iniset $TEMPEST_CONFIG baremetal_feature_enabled trunks_supported True
 }
 
 # check for service enabled

--- a/networking_generic_switch/devices/__init__.py
+++ b/networking_generic_switch/devices/__init__.py
@@ -109,6 +109,14 @@ class GenericSwitchDevice(object, metaclass=abc.ABCMeta):
 
         self._validate_network_name_format()
 
+    @property
+    def support_trunk_on_ports(self):
+        return False
+
+    @property
+    def support_trunk_on_bond_ports(self):
+        return False
+
     def _validate_network_name_format(self):
         """Validate the network name format configuration option."""
         network_name_format = self.ngs_config['ngs_network_name_format']
@@ -193,17 +201,78 @@ class GenericSwitchDevice(object, metaclass=abc.ABCMeta):
         pass
 
     @abc.abstractmethod
-    def plug_port_to_network(self, port_id, segmentation_id):
+    def plug_port_to_network(self, port_id, segmentation_id,
+                             trunk_details=None):
+        """Plug port into network.
+
+        :param port_id: Then name of the switch interface
+        :param segmentation_id: VLAN identifier of the network used as access
+               or native VLAN for port.
+
+        :param trunk_details: trunk information if port is a part of trunk
+        """
         pass
 
     @abc.abstractmethod
-    def delete_port(self, port_id, segmentation_id):
+    def delete_port(self, port_id, segmentation_id, trunk_details=None):
+        """Delete port from specific network.
+
+        :param port_id: Then name of the switch interface
+        :param segmentation_id: VLAN identifier of the network used as access
+               or native VLAN for port.
+
+        :param trunk_details: trunk information if port is a part of trunk
+        """
         pass
 
-    def plug_bond_to_network(self, bond_id, segmentation_id):
-        # Fall back to interface method.
-        return self.plug_port_to_network(bond_id, segmentation_id)
+    def plug_bond_to_network(self, bond_id, segmentation_id,
+                             trunk_details=None):
+        """Plug bond port into network.
 
-    def unplug_bond_from_network(self, bond_id, segmentation_id):
+        :param port_id: Then name of the switch interface
+        :param segmentation_id: VLAN identifier of the network used as access
+               or native VLAN for port.
+
+        :param trunk_details: trunk information if port is a part of trunk
+        """
+        kwargs = {}
+        if trunk_details:
+            kwargs["trunk_details"] = trunk_details
         # Fall back to interface method.
-        return self.delete_port(bond_id, segmentation_id)
+        return self.plug_port_to_network(bond_id, segmentation_id, **kwargs)
+
+    def unplug_bond_from_network(self, bond_id, segmentation_id,
+                                 trunk_details=None):
+        """Unplug bond port from network.
+
+        :param port_id: Then name of the switch interface
+        :param segmentation_id: VLAN identifier of the network used as access
+               or native VLAN for port.
+
+        :param trunk_details: trunk information if port is a part of trunk
+        """
+        kwargs = {}
+        if trunk_details:
+            kwargs["trunk_details"] = trunk_details
+        # Fall back to interface method.
+        return self.delete_port(bond_id, segmentation_id, **kwargs)
+
+    def add_subports_on_trunk(self, binding_profile, port_id, subports):
+        """Allow subports on trunk
+
+        :param binding_profile: Binding profile of parent port
+        :param port_id: The name of the switch port from
+               Local Link Information
+        :param subports: List with subports objects.
+        """
+        pass
+
+    def del_subports_on_trunk(self, binding_profile, port_id, subports):
+        """Allow subports on trunk
+
+        :param binding_profile: Binding profile of parent port
+        :param port_id: The name of the switch port from
+               Local Link Information
+        :param subports: List with subports objects.
+        """
+        pass

--- a/networking_generic_switch/devices/netmiko_devices/__init__.py
+++ b/networking_generic_switch/devices/netmiko_devices/__init__.py
@@ -29,6 +29,7 @@ from networking_generic_switch import devices
 from networking_generic_switch.devices import utils as device_utils
 from networking_generic_switch import exceptions as exc
 from networking_generic_switch import locking as ngs_lock
+from networking_generic_switch import utils as ngs_utils
 
 LOG = logging.getLogger(__name__)
 CONF = cfg.CONF
@@ -92,7 +93,19 @@ class NetmikoSwitch(devices.GenericSwitchDevice):
 
     SET_NATIVE_VLAN = None
 
-    ALLOW_NETWORK_ON_TRUNK = None
+    DELETE_NATIVE_VLAN = None
+
+    SET_NATIVE_VLAN_BOND = None
+
+    DELETE_NATIVE_VLAN_BOND = None
+
+    ADD_NETWORK_TO_TRUNK = None
+
+    REMOVE_NETWORK_FROM_TRUNK = None
+
+    ADD_NETWORK_TO_BOND_TRUNK = None
+
+    DELETE_NETWORK_ON_BOND_TRUNK = None
 
     ERROR_MSG_PATTERNS = ()
     """Sequence of error message patterns.
@@ -148,6 +161,14 @@ class NetmikoSwitch(devices.GenericSwitchDevice):
                 ('ngs-' + device_utils.get_hostname()).encode('ascii'))
             self.locker.start()
             atexit.register(self.locker.stop)
+
+    @property
+    def support_trunk_on_ports(self):
+        return bool(self.ADD_NETWORK_TO_TRUNK)
+
+    @property
+    def support_trunk_on_bond_ports(self):
+        return bool(self.ADD_NETWORK_TO_BOND_TRUNK)
 
     def _format_commands(self, commands, **kwargs):
         if not commands:
@@ -303,7 +324,7 @@ class NetmikoSwitch(devices.GenericSwitchDevice):
         self.send_commands_to_device(cmd_set)
 
     @check_output('plug port')
-    def plug_port_to_network(self, port, segmentation_id):
+    def plug_port_to_network(self, port, segmentation_id, trunk_details=None):
         cmds = []
         if self._disable_inactive_ports() and self.ENABLE_PORT:
             cmds += self._format_commands(self.ENABLE_PORT, port=port)
@@ -313,18 +334,38 @@ class NetmikoSwitch(devices.GenericSwitchDevice):
                 self.DELETE_PORT,
                 port=port,
                 segmentation_id=ngs_port_default_vlan)
-        cmds += self._format_commands(
-            self.PLUG_PORT_TO_NETWORK,
-            port=port,
-            segmentation_id=segmentation_id)
+
+        if trunk_details:
+            cmds += self._format_commands(self.SET_NATIVE_VLAN,
+                                          port=port,
+                                          segmentation_id=segmentation_id)
+            for sub_port in trunk_details.get('sub_ports', []):
+                cmds += self._format_commands(
+                    self.ADD_NETWORK_TO_TRUNK, port=port,
+                    segmentation_id=sub_port['segmentation_id'])
+        else:
+            cmds += self._format_commands(
+                self.PLUG_PORT_TO_NETWORK,
+                port=port,
+                segmentation_id=segmentation_id)
+
         return self.send_commands_to_device(cmds)
 
     @check_output('unplug port')
-    def delete_port(self, port, segmentation_id):
+    def delete_port(self, port, segmentation_id, trunk_details=None):
         cmds = self._format_commands(self.DELETE_PORT,
                                      port=port,
                                      segmentation_id=segmentation_id)
         ngs_port_default_vlan = self._get_port_default_vlan()
+        if trunk_details:
+            cmds += self._format_commands(self.DELETE_NATIVE_VLAN,
+                                          port=port,
+                                          segmentation_id=segmentation_id)
+            for sub_port in trunk_details.get('sub_ports', []):
+                cmds += self._format_commands(
+                    self.REMOVE_NETWORK_FROM_TRUNK, port=port,
+                    segmentation_id=sub_port['segmentation_id'])
+
         if ngs_port_default_vlan:
             # NOTE(mgoddard): Pass network_id and segmentation_id for drivers
             # not yet using network_name.
@@ -341,14 +382,16 @@ class NetmikoSwitch(devices.GenericSwitchDevice):
                 segmentation_id=ngs_port_default_vlan)
         if self._disable_inactive_ports() and self.DISABLE_PORT:
             cmds += self._format_commands(self.DISABLE_PORT, port=port)
+
         return self.send_commands_to_device(cmds)
 
     @check_output('plug bond')
-    def plug_bond_to_network(self, bond, segmentation_id):
+    def plug_bond_to_network(self, bond, segmentation_id, trunk_details=None):
         # Fallback to regular plug port if no specialist PLUG_BOND_TO_NETWORK
         # commands set
         if not self.PLUG_BOND_TO_NETWORK:
-            return self.plug_port_to_network(bond, segmentation_id)
+            return self.plug_port_to_network(bond, segmentation_id,
+                                             trunk_details=trunk_details)
         cmds = []
         if self._disable_inactive_ports() and self.ENABLE_BOND:
             cmds += self._format_commands(self.ENABLE_BOND, bond=bond)
@@ -358,22 +401,44 @@ class NetmikoSwitch(devices.GenericSwitchDevice):
                 self.UNPLUG_BOND_FROM_NETWORK,
                 bond=bond,
                 segmentation_id=ngs_port_default_vlan)
-        cmds += self._format_commands(
-            self.PLUG_BOND_TO_NETWORK,
-            bond=bond,
-            segmentation_id=segmentation_id)
+
+        if trunk_details:
+            cmds += self._format_commands(self.SET_NATIVE_VLAN_BOND,
+                                          bond=bond,
+                                          segmentation_id=segmentation_id)
+            for sub_port in trunk_details.get('sub_ports', []):
+                cmds += self._format_commands(
+                    self.ADD_NETWORK_TO_BOND_TRUNK, bond=bond,
+                    segmentation_id=sub_port['segmentation_id'])
+        else:
+            cmds += self._format_commands(
+                self.PLUG_BOND_TO_NETWORK,
+                bond=bond,
+                segmentation_id=segmentation_id)
+
         return self.send_commands_to_device(cmds)
 
     @check_output('unplug bond')
-    def unplug_bond_from_network(self, bond, segmentation_id):
+    def unplug_bond_from_network(self, bond, segmentation_id,
+                                 trunk_details=None):
         # Fallback to regular port delete if no specialist
         # UNPLUG_BOND_FROM_NETWORK commands set
         if not self.UNPLUG_BOND_FROM_NETWORK:
-            return self.delete_port(bond, segmentation_id)
+            return self.delete_port(bond, segmentation_id,
+                                    trunk_details=trunk_details)
         cmds = self._format_commands(self.UNPLUG_BOND_FROM_NETWORK,
                                      bond=bond,
                                      segmentation_id=segmentation_id)
         ngs_port_default_vlan = self._get_port_default_vlan()
+        if trunk_details:
+            cmds += self._format_commands(self.DELETE_NATIVE_VLAN_BOND,
+                                          bond=bond,
+                                          segmentation_id=segmentation_id)
+            for sub_port in trunk_details.get('sub_ports', []):
+                cmds += self._format_commands(
+                    self.ADD_NETWORK_TO_BOND_TRUNK, bond=bond,
+                    segmentation_id=sub_port['segmentation_id'])
+
         if ngs_port_default_vlan:
             # NOTE(mgoddard): Pass network_id and segmentation_id for drivers
             # not yet using network_name.
@@ -390,6 +455,7 @@ class NetmikoSwitch(devices.GenericSwitchDevice):
                 segmentation_id=ngs_port_default_vlan)
         if self._disable_inactive_ports() and self.DISABLE_BOND:
             cmds += self._format_commands(self.DISABLE_BOND, bond=bond)
+
         return self.send_commands_to_device(cmds)
 
     def send_config_set(self, net_connect, cmd_set):
@@ -444,21 +510,47 @@ class NetmikoSwitch(devices.GenericSwitchDevice):
                     config=device_utils.sanitise_config(self.config),
                     error=msg)
 
-    def get_trunk_port_cmds_no_vlan_translation(self, port_id,
-                                                segmentation_id,
-                                                trunk_details):
-        cmd_set = []
-        cmd_set.extend(
-            self._format_commands(self.SET_NATIVE_VLAN,
-                                  port=port_id,
-                                  segmentation_id=segmentation_id))
-        for sub_port in trunk_details.get('sub_ports'):
-            cmd_set.extend(
-                self._format_commands(
-                    self.ALLOW_NETWORK_ON_TRUNK, port=port_id,
-                    segmentation_id=sub_port['segmentation_id']))
-        return cmd_set
+    def add_subports_on_trunk(self, binding_profile, port_id, subports):
+        """Allow subports on trunk
 
-    def get_trunk_port_cmds_vlan_translation(self, port_id, segmentation_id,
-                                             trunk_details):
-        pass
+        :param binding_profile: Binding profile of parent port
+        :param port_id: The name of the switch port from
+               Local Link Information
+        :param subports: List with subports objects.
+        """
+        cmds = []
+        is_802_3ad = ngs_utils.is_802_3ad(binding_profile)
+
+        for sub_port in subports:
+            if is_802_3ad:
+                cmds += self._format_commands(
+                    self.ADD_NETWORK_TO_BOND_TRUNK, bond=port_id,
+                    segmentation_id=sub_port['segmentation_id'])
+            else:
+                cmds += self._format_commands(
+                    self.ADD_NETWORK_TO_TRUNK, port=port_id,
+                    segmentation_id=sub_port['segmentation_id'])
+        return self.send_commands_to_device(cmds)
+
+    def del_subports_on_trunk(self, binding_profile, port_id, subports):
+        """Allow subports on trunk
+
+        :param binding_profile: Binding profile of parent port
+        :param port_id: The name of the switch port from
+               Local Link Information
+        :param subports: List with subports objects.
+        """
+
+        cmds = []
+        is_802_3ad = ngs_utils.is_802_3ad(binding_profile)
+
+        for sub_port in subports:
+            if is_802_3ad:
+                cmds += self._format_commands(
+                    self.DELETE_NETWORK_ON_BOND_TRUNK, bond=port_id,
+                    segmentation_id=sub_port['segmentation_id'])
+            else:
+                cmds += self._format_commands(
+                    self.REMOVE_NETWORK_FROM_TRUNK, port=port_id,
+                    segmentation_id=sub_port['segmentation_id'])
+        return self.send_commands_to_device(cmds)

--- a/networking_generic_switch/devices/netmiko_devices/arista.py
+++ b/networking_generic_switch/devices/netmiko_devices/arista.py
@@ -45,7 +45,18 @@ class AristaEos(netmiko_devices.NetmikoSwitch):
         'switchport trunk allowed vlan add {segmentation_id}'
     )
 
-    ALLOW_NETWORK_ON_TRUNK = (
+    DELETE_NATIVE_VLAN = (
+        'interface {port}',
+        'no switchport trunk native vlan {segmentation_id}',
+        'switchport trunk allowed vlan remove {segmentation_id}',
+    )
+
+    ADD_NETWORK_TO_TRUNK = (
         'interface {port}',
         'switchport trunk allowed vlan add {segmentation_id}'
+    )
+
+    REMOVE_NETWORK_FROM_TRUNK = (
+        'interface {port}',
+        'switchport trunk allowed vlan remove {segmentation_id}'
     )

--- a/networking_generic_switch/devices/netmiko_devices/cisco.py
+++ b/networking_generic_switch/devices/netmiko_devices/cisco.py
@@ -43,12 +43,25 @@ class CiscoIos(netmiko_devices.NetmikoSwitch):
         'interface {port}',
         'switchport mode trunk',
         'switchport trunk native vlan {segmentation_id}',
-        'switchport trunk allowed vlan add {segmentation_id}'
+        'switchport trunk allowed vlan add {segmentation_id}',
     )
 
-    ALLOW_NETWORK_ON_TRUNK = (
+    DELETE_NATIVE_VLAN = (
         'interface {port}',
-        'switchport trunk allowed vlan add {segmentation_id}'
+        'no switchport mode trunk',
+        'no switchport trunk native vlan {segmentation_id}',
+        'switchport trunk allowed vlan remove {segmentation_id}',
+    )
+
+    ADD_NETWORK_TO_TRUNK = (
+        'interface {port}',
+        'switchport mode trunk',
+        'switchport trunk allowed vlan add {segmentation_id}',
+    )
+
+    REMOVE_NETWORK_FROM_TRUNK = (
+        'interface {port}',
+        'switchport trunk allowed vlan remove {segmentation_id}',
     )
 
 

--- a/networking_generic_switch/devices/netmiko_devices/ovs.py
+++ b/networking_generic_switch/devices/netmiko_devices/ovs.py
@@ -27,3 +27,43 @@ class OvsLinux(netmiko_devices.NetmikoSwitch):
         'ovs-vsctl clear port {port} trunks',
         'ovs-vsctl clear port {port} vlan_mode'
     )
+
+    SET_NATIVE_VLAN = (
+        'ovs-vsctl set port {port} vlan_mode=native-untagged',
+        'ovs-vsctl set port {port} tag={segmentation_id}',
+        'ovs-vsctl add port {port} trunks {segmentation_id}',
+    )
+
+    DELETE_NATIVE_VLAN = (
+        'ovs-vsctl clear port {port} vlan_mode',
+        'ovs-vsctl clear port {port} tag',
+        'ovs-vsctl remove port {port} trunks {segmentation_id}',
+    )
+
+    SET_NATIVE_VLAN_BOND = (
+        'ovs-vsctl set port {bond} vlan_mode=native-untagged',
+        'ovs-vsctl set port {bond} tag={segmentation_id}',
+        'ovs-vsctl add port {bond} trunks {segmentation_id}',
+    )
+
+    DELETE_NATIVE_VLAN_BOND = (
+        'ovs-vsctl clear port {bond} vlan_mode',
+        'ovs-vsctl clear port {bond} tag',
+        'ovs-vsctl remove port {bond} trunks {segmentation_id}',
+    )
+
+    ADD_NETWORK_TO_TRUNK = (
+        'ovs-vsctl add port {port} trunks {segmentation_id}',
+    )
+
+    REMOVE_NETWORK_FROM_TRUNK = (
+        'ovs-vsctl remove port {port} trunks {segmentation_id}',
+    )
+
+    ADD_NETWORK_TO_BOND_TRUNK = (
+        'ovs-vsctl add port {bond} trunks {segmentation_id}',
+    )
+
+    DELETE_NETWORK_ON_BOND_TRUNK = (
+        'ovs-vsctl remove port {bond} trunks {segmentation_id}',
+    )

--- a/networking_generic_switch/exceptions.py
+++ b/networking_generic_switch/exceptions.py
@@ -56,5 +56,5 @@ class GenericSwitchBatchError(GenericSwitchException):
 
 
 class GenericSwitchNotSupported(GenericSwitchException):
-    message = _("Requested feature is not supported by "
-                "networking-generic-switch. %(error)s")
+    message = _("Requested feature %(feature)s is not supported by "
+                "networking-generic-switch on the %(switch)s. %(error)s")

--- a/networking_generic_switch/tests/unit/netmiko/test_arista_eos.py
+++ b/networking_generic_switch/tests/unit/netmiko/test_arista_eos.py
@@ -14,7 +14,7 @@
 
 from unittest import mock
 
-from neutron.plugins.ml2 import driver_context
+from oslo_utils import uuidutils
 
 from networking_generic_switch.devices.netmiko_devices import arista
 from networking_generic_switch.tests.unit.netmiko import test_netmiko_base
@@ -125,3 +125,166 @@ class TestNetmikoAristaEos(test_netmiko_base.NetmikoSwitchTestBase):
                    'no switchport mode trunk',
                    'switchport trunk allowed vlan none']
         self.assertEqual(del_exp, cmd_set)
+
+    @mock.patch('networking_generic_switch.devices.netmiko_devices.'
+                'NetmikoSwitch.send_commands_to_device', autospec=True)
+    def test_plug_port_to_network_subports(self, mock_exec):
+        trunk_details = {"sub_ports": [{"segmentation_id": "tag1"},
+                                       {"segmentation_id": "tag2"}]}
+        self.switch.plug_port_to_network(4444, 44, trunk_details=trunk_details)
+        mock_exec.assert_called_with(
+            self.switch,
+            ['interface 4444',
+             'switchport mode trunk',
+             'switchport trunk native vlan 44',
+             'switchport trunk allowed vlan add 44',
+             'interface 4444',
+             'switchport trunk allowed vlan add tag1',
+             'interface 4444',
+             'switchport trunk allowed vlan add tag2'])
+
+    @mock.patch('networking_generic_switch.devices.netmiko_devices.'
+                'NetmikoSwitch.send_commands_to_device', autospec=True)
+    def test_delete_port_subports(self, mock_exec):
+        trunk_details = {"sub_ports": [{"segmentation_id": "tag1"},
+                                       {"segmentation_id": "tag2"}]}
+        self.switch.delete_port(4444, 44, trunk_details=trunk_details)
+        mock_exec.assert_called_with(
+            self.switch,
+            ['interface 4444',
+             'no switchport access vlan 44',
+             'no switchport mode trunk',
+             'switchport trunk allowed vlan none',
+             'interface 4444',
+             'no switchport trunk native vlan 44',
+             'switchport trunk allowed vlan remove 44',
+             'interface 4444',
+             'switchport trunk allowed vlan remove tag1',
+             'interface 4444',
+             'switchport trunk allowed vlan remove tag2'])
+
+    @mock.patch('networking_generic_switch.devices.netmiko_devices.'
+                'NetmikoSwitch.send_commands_to_device', autospec=True)
+    def test_plug_bond_to_network_subports(self, mock_exec):
+        trunk_details = {"sub_ports": [{"segmentation_id": "tag1"},
+                                       {"segmentation_id": "tag2"}]}
+        self.switch.plug_bond_to_network(4444, 44, trunk_details=trunk_details)
+        mock_exec.assert_called_with(
+            self.switch,
+            ['interface 4444',
+             'switchport mode trunk',
+             'switchport trunk native vlan 44',
+             'switchport trunk allowed vlan add 44',
+             'interface 4444',
+             'switchport trunk allowed vlan add tag1',
+             'interface 4444',
+             'switchport trunk allowed vlan add tag2'])
+
+    @mock.patch('networking_generic_switch.devices.netmiko_devices.'
+                'NetmikoSwitch.send_commands_to_device', autospec=True)
+    def test_unplug_bond_from_network_subports(self, mock_exec):
+        trunk_details = {"sub_ports": [{"segmentation_id": "tag1"},
+                                       {"segmentation_id": "tag2"}]}
+        self.switch.unplug_bond_from_network(
+            4444, 44, trunk_details=trunk_details)
+        mock_exec.assert_called_with(
+            self.switch,
+            ['interface 4444',
+             'no switchport access vlan 44',
+             'no switchport mode trunk',
+             'switchport trunk allowed vlan none',
+             'interface 4444',
+             'no switchport trunk native vlan 44',
+             'switchport trunk allowed vlan remove 44',
+             'interface 4444',
+             'switchport trunk allowed vlan remove tag1',
+             'interface 4444',
+             'switchport trunk allowed vlan remove tag2'])
+
+    @mock.patch('networking_generic_switch.devices.netmiko_devices.'
+                'NetmikoSwitch.send_commands_to_device', autospec=True)
+    def test_add_subports_on_trunk_no_subports(self, mock_exec):
+        port_id = uuidutils.generate_uuid()
+        parent_port = {
+            'binding:profile': {
+                'local_link_information': [
+                    {
+                        'switch_info': 'bar',
+                        'port_id': 2222
+                    }
+                ]},
+            'binding:vnic_type': 'baremetal',
+            'id': port_id
+        }
+        subports = []
+        self.switch.add_subports_on_trunk(parent_port, 44, subports=subports)
+        mock_exec.assert_called_with(self.switch, [])
+
+    @mock.patch('networking_generic_switch.devices.netmiko_devices.'
+                'NetmikoSwitch.send_commands_to_device', autospec=True)
+    def test_add_subports_on_trunk_subports(self, mock_exec):
+        port_id = uuidutils.generate_uuid()
+        parent_port = {
+            'binding:profile': {
+                'local_link_information': [
+                    {
+                        'switch_info': 'bar',
+                        'port_id': 2222
+                    }
+                ]},
+            'binding:vnic_type': 'baremetal',
+            'id': port_id
+        }
+        subports = [{"segmentation_id": "tag1"},
+                    {"segmentation_id": "tag2"}]
+        self.switch.add_subports_on_trunk(parent_port, 44, subports=subports)
+        mock_exec.assert_called_with(
+            self.switch,
+            ['interface 44',
+             'switchport trunk allowed vlan add tag1',
+             'interface 44',
+             'switchport trunk allowed vlan add tag2'])
+
+    @mock.patch('networking_generic_switch.devices.netmiko_devices.'
+                'NetmikoSwitch.send_commands_to_device', autospec=True)
+    def test_del_subports_on_trunk_no_subports(self, mock_exec):
+        port_id = uuidutils.generate_uuid()
+        parent_port = {
+            'binding:profile': {
+                'local_link_information': [
+                    {
+                        'switch_info': 'bar',
+                        'port_id': 2222
+                    }
+                ]},
+            'binding:vnic_type': 'baremetal',
+            'id': port_id
+        }
+        subports = []
+        self.switch.del_subports_on_trunk(parent_port, 44, subports=subports)
+        mock_exec.assert_called_with(self.switch, [])
+
+    @mock.patch('networking_generic_switch.devices.netmiko_devices.'
+                'NetmikoSwitch.send_commands_to_device', autospec=True)
+    def test_del_subports_on_trunk_subports(self, mock_exec):
+        port_id = uuidutils.generate_uuid()
+        parent_port = {
+            'binding:profile': {
+                'local_link_information': [
+                    {
+                        'switch_info': 'bar',
+                        'port_id': 2222
+                    }
+                ]},
+            'binding:vnic_type': 'baremetal',
+            'id': port_id
+        }
+        subports = [{"segmentation_id": "tag1"},
+                    {"segmentation_id": "tag2"}]
+        self.switch.del_subports_on_trunk(parent_port, 44, subports=subports)
+        mock_exec.assert_called_with(
+            self.switch,
+            ['interface 44',
+             'switchport trunk allowed vlan remove tag1',
+             'interface 44',
+             'switchport trunk allowed vlan remove tag2'])

--- a/networking_generic_switch/tests/unit/netmiko/test_cisco_ios.py
+++ b/networking_generic_switch/tests/unit/netmiko/test_cisco_ios.py
@@ -14,7 +14,7 @@
 
 from unittest import mock
 
-from neutron.plugins.ml2 import driver_context
+from oslo_utils import uuidutils
 
 from networking_generic_switch.devices.netmiko_devices import cisco
 from networking_generic_switch.tests.unit.netmiko import test_netmiko_base
@@ -125,3 +125,174 @@ class TestNetmikoCiscoIos(test_netmiko_base.NetmikoSwitchTestBase):
                    'no switchport mode trunk',
                    'switchport trunk allowed vlan none']
         self.assertEqual(del_exp, cmd_set)
+
+    @mock.patch('networking_generic_switch.devices.netmiko_devices.'
+                'NetmikoSwitch.send_commands_to_device', autospec=True)
+    def test_plug_port_to_network_subports(self, mock_exec):
+        trunk_details = {"sub_ports": [{"segmentation_id": "tag1"},
+                                       {"segmentation_id": "tag2"}]}
+        self.switch.plug_port_to_network(4444, 44, trunk_details=trunk_details)
+        mock_exec.assert_called_with(
+            self.switch,
+            ['interface 4444',
+             'switchport mode trunk',
+             'switchport trunk native vlan 44',
+             'switchport trunk allowed vlan add 44',
+             'interface 4444',
+             'switchport mode trunk',
+             'switchport trunk allowed vlan add tag1',
+             'interface 4444',
+             'switchport mode trunk',
+             'switchport trunk allowed vlan add tag2'])
+
+    @mock.patch('networking_generic_switch.devices.netmiko_devices.'
+                'NetmikoSwitch.send_commands_to_device', autospec=True)
+    def test_delete_port_subports(self, mock_exec):
+        trunk_details = {"sub_ports": [{"segmentation_id": "tag1"},
+                                       {"segmentation_id": "tag2"}]}
+        self.switch.delete_port(4444, 44, trunk_details=trunk_details)
+        mock_exec.assert_called_with(
+            self.switch,
+            ['interface 4444',
+             'no switchport access vlan 44',
+             'no switchport mode trunk',
+             'switchport trunk allowed vlan none',
+             'interface 4444',
+             'no switchport mode trunk',
+             'no switchport trunk native vlan 44',
+             'switchport trunk allowed vlan remove 44',
+             'interface 4444',
+             'switchport trunk allowed vlan remove tag1',
+             'interface 4444',
+             'switchport trunk allowed vlan remove tag2'])
+
+    @mock.patch('networking_generic_switch.devices.netmiko_devices.'
+                'NetmikoSwitch.send_commands_to_device', autospec=True)
+    def test_plug_bond_to_network_subports(self, mock_exec):
+        trunk_details = {"sub_ports": [{"segmentation_id": "tag1"},
+                                       {"segmentation_id": "tag2"}]}
+        self.switch.plug_bond_to_network(4444, 44, trunk_details=trunk_details)
+        mock_exec.assert_called_with(
+            self.switch,
+            ['interface 4444',
+             'switchport mode trunk',
+             'switchport trunk native vlan 44',
+             'switchport trunk allowed vlan add 44',
+             'interface 4444',
+             'switchport mode trunk',
+             'switchport trunk allowed vlan add tag1',
+             'interface 4444',
+             'switchport mode trunk',
+             'switchport trunk allowed vlan add tag2'])
+
+    @mock.patch('networking_generic_switch.devices.netmiko_devices.'
+                'NetmikoSwitch.send_commands_to_device', autospec=True)
+    def test_unplug_bond_from_network_subports(self, mock_exec):
+        trunk_details = {"sub_ports": [{"segmentation_id": "tag1"},
+                                       {"segmentation_id": "tag2"}]}
+        self.switch.unplug_bond_from_network(
+            4444, 44, trunk_details=trunk_details)
+        mock_exec.assert_called_with(
+            self.switch,
+            ['interface 4444',
+             'no switchport access vlan 44',
+             'no switchport mode trunk',
+             'switchport trunk allowed vlan none',
+             'interface 4444',
+             'no switchport mode trunk',
+             'no switchport trunk native vlan 44',
+             'switchport trunk allowed vlan remove 44',
+             'interface 4444',
+             'switchport trunk allowed vlan remove tag1',
+             'interface 4444',
+             'switchport trunk allowed vlan remove tag2'])
+
+    @mock.patch('networking_generic_switch.devices.netmiko_devices.'
+                'NetmikoSwitch.send_commands_to_device', autospec=True)
+    def test_add_subports_on_trunk_no_subports(self, mock_exec):
+        port_id = uuidutils.generate_uuid()
+        parent_port = {
+            'binding:profile': {
+                'local_link_information': [
+                    {
+                        'switch_info': 'bar',
+                        'port_id': 2222
+                    }
+                ]},
+            'binding:vnic_type': 'baremetal',
+            'id': port_id
+        }
+        subports = []
+        self.switch.add_subports_on_trunk(parent_port, 44, subports=subports)
+        mock_exec.assert_called_with(self.switch, [])
+
+    @mock.patch('networking_generic_switch.devices.netmiko_devices.'
+                'NetmikoSwitch.send_commands_to_device', autospec=True)
+    def test_add_subports_on_trunk_subports(self, mock_exec):
+        port_id = uuidutils.generate_uuid()
+        parent_port = {
+            'binding:profile': {
+                'local_link_information': [
+                    {
+                        'switch_info': 'bar',
+                        'port_id': 2222
+                    }
+                ]},
+            'binding:vnic_type': 'baremetal',
+            'id': port_id
+        }
+        subports = [{"segmentation_id": "tag1"},
+                    {"segmentation_id": "tag2"}]
+        self.switch.add_subports_on_trunk(parent_port, 44, subports=subports)
+        mock_exec.assert_called_with(
+            self.switch,
+            ['interface 44',
+             'switchport mode trunk',
+             'switchport trunk allowed vlan add tag1',
+             'interface 44',
+             'switchport mode trunk',
+             'switchport trunk allowed vlan add tag2'])
+
+    @mock.patch('networking_generic_switch.devices.netmiko_devices.'
+                'NetmikoSwitch.send_commands_to_device', autospec=True)
+    def test_del_subports_on_trunk_no_subports(self, mock_exec):
+        port_id = uuidutils.generate_uuid()
+        parent_port = {
+            'binding:profile': {
+                'local_link_information': [
+                    {
+                        'switch_info': 'bar',
+                        'port_id': 2222
+                    }
+                ]},
+            'binding:vnic_type': 'baremetal',
+            'id': port_id
+        }
+        subports = []
+        self.switch.del_subports_on_trunk(parent_port, 44, subports=subports)
+        mock_exec.assert_called_with(self.switch, [])
+
+    @mock.patch('networking_generic_switch.devices.netmiko_devices.'
+                'NetmikoSwitch.send_commands_to_device', autospec=True)
+    def test_del_subports_on_trunk_subports(self, mock_exec):
+        port_id = uuidutils.generate_uuid()
+        parent_port = {
+            'binding:profile': {
+                'local_link_information': [
+                    {
+                        'switch_info': 'bar',
+                        'port_id': 2222
+                    }
+                ]},
+            'binding:vnic_type': 'baremetal',
+            'id': port_id
+        }
+        subports = [{"segmentation_id": "tag1"},
+                    {"segmentation_id": "tag2"}]
+        self.switch.del_subports_on_trunk(parent_port, 44, subports=subports)
+        mock_exec.assert_called_with(
+            self.switch,
+            ['interface 44',
+             'switchport trunk allowed vlan remove tag1',
+             'interface 44',
+             'switchport trunk allowed vlan remove tag2'])

--- a/networking_generic_switch/tests/unit/netmiko/test_netmiko_base.py
+++ b/networking_generic_switch/tests/unit/netmiko/test_netmiko_base.py
@@ -34,6 +34,7 @@ class NetmikoSwitchTestBase(fixtures.TestWithFixtures):
         super(NetmikoSwitchTestBase, self).setUp()
         self.cfg = self.useFixture(config_fixture.Config())
         self.switch = self._make_switch_device()
+        self.ctxt = mock.MagicMock()
 
     def _make_switch_device(self, extra_cfg={}):
         patcher = mock.patch.object(
@@ -160,9 +161,10 @@ class TestNetmikoSwitch(NetmikoSwitchTestBase):
     @mock.patch('networking_generic_switch.devices.netmiko_devices.'
                 'NetmikoSwitch.check_output')
     def test_delete_port(self, m_check, m_sctd):
-        self.switch.delete_port(2222, 22)
-        m_sctd.assert_called_with([])
-        m_check.assert_called_once_with('fake output', 'unplug port')
+        self.switch.delete_port(2222, 22, trunk_details={})
+        m_sctd.assert_called_with(self.switch, [])
+        m_check.assert_called_once_with(self.switch,
+                                        'fake output', 'unplug port')
 
     @mock.patch('networking_generic_switch.devices.netmiko_devices.'
                 'NetmikoSwitch.send_commands_to_device',
@@ -171,9 +173,9 @@ class TestNetmikoSwitch(NetmikoSwitchTestBase):
                 'NetmikoSwitch.check_output')
     def test_delete_port_has_default_vlan(self, m_check, m_sctd):
         switch = self._make_switch_device({'ngs_port_default_vlan': '20'})
-        switch.delete_port(2222, 22)
-        m_sctd.assert_called_with([])
-        m_check.assert_called_once_with('fake output', 'unplug port')
+        switch.delete_port(2222, 22, trunk_details={})
+        m_sctd.assert_called_with(switch, [])
+        m_check.assert_called_once_with(switch, 'fake output', 'unplug port')
 
     @mock.patch('networking_generic_switch.devices.netmiko_devices.'
                 'NetmikoSwitch.send_commands_to_device',
@@ -192,14 +194,14 @@ class TestNetmikoSwitch(NetmikoSwitchTestBase):
                 return_value='fake output')
     def test_plug_bond_to_network_fallback(self, m_plug):
         self.switch.plug_bond_to_network(2222, 22)
-        m_plug.assert_called_with(2222, 22)
+        m_plug.assert_called_with(self.switch, 2222, 22, trunk_details=None)
 
     @mock.patch('networking_generic_switch.devices.netmiko_devices.'
                 'NetmikoSwitch.delete_port',
                 return_value='fake output')
     def test_unplug_bond_from_network_fallback(self, m_delete):
         self.switch.unplug_bond_from_network(2222, 22)
-        m_delete.assert_called_with(2222, 22)
+        m_delete.assert_called_with(self.switch, 2222, 22, trunk_details=None)
 
     def test__format_commands(self):
         self.switch._format_commands(

--- a/networking_generic_switch/tests/unit/netmiko/test_ovs_linux.py
+++ b/networking_generic_switch/tests/unit/netmiko/test_ovs_linux.py
@@ -14,6 +14,8 @@
 
 from unittest import mock
 
+from oslo_utils import uuidutils
+
 from networking_generic_switch.devices.netmiko_devices import ovs
 from networking_generic_switch.tests.unit.netmiko import test_netmiko_base
 
@@ -27,6 +29,10 @@ class TestNetmikoOvsLinux(test_netmiko_base.NetmikoSwitchTestBase):
 
     def test_constants(self):
         self.assertIsNone(self.switch.SAVE_CONFIGURATION)
+
+    def test_features(self):
+        self.assertTrue(self.switch.support_trunk_on_ports)
+        self.assertTrue(self.switch.support_trunk_on_bond_ports)
 
     @mock.patch('networking_generic_switch.devices.netmiko_devices.'
                 'NetmikoSwitch.send_commands_to_device')
@@ -49,13 +55,158 @@ class TestNetmikoOvsLinux(test_netmiko_base.NetmikoSwitchTestBase):
              'ovs-vsctl set port 4444 tag=44'])
 
     @mock.patch('networking_generic_switch.devices.netmiko_devices.'
-                'NetmikoSwitch.send_commands_to_device')
+                'NetmikoSwitch.send_commands_to_device', autospec=True)
+    def test_plug_port_to_network_subports(self, mock_exec):
+        trunk_details = {"sub_ports": [{"segmentation_id": "tag1"},
+                                       {"segmentation_id": "tag2"}]}
+        self.switch.plug_port_to_network(4444, 44, trunk_details=trunk_details)
+        mock_exec.assert_called_with(
+            self.switch,
+            ['ovs-vsctl set port 4444 vlan_mode=native-untagged',
+             'ovs-vsctl set port 4444 tag=44',
+             'ovs-vsctl add port 4444 trunks 44',
+             'ovs-vsctl add port 4444 trunks tag1',
+             'ovs-vsctl add port 4444 trunks tag2'])
+
+    @mock.patch('networking_generic_switch.devices.netmiko_devices.'
+                'NetmikoSwitch.send_commands_to_device', autospec=True)
     def test_delete_port(self, mock_exec):
         self.switch.delete_port(4444, 44)
         mock_exec.assert_called_with(
             ['ovs-vsctl clear port 4444 tag',
              'ovs-vsctl clear port 4444 trunks',
              'ovs-vsctl clear port 4444 vlan_mode'])
+
+    @mock.patch('networking_generic_switch.devices.netmiko_devices.'
+                'NetmikoSwitch.send_commands_to_device', autospec=True)
+    def test_delete_port_subports(self, mock_exec):
+        trunk_details = {"sub_ports": [{"segmentation_id": "tag1"},
+                                       {"segmentation_id": "tag2"}]}
+        self.switch.delete_port(4444, 44, trunk_details=trunk_details)
+        mock_exec.assert_called_with(
+            self.switch,
+            ['ovs-vsctl clear port 4444 tag',
+             'ovs-vsctl clear port 4444 trunks',
+             'ovs-vsctl clear port 4444 vlan_mode',
+             'ovs-vsctl clear port 4444 vlan_mode',
+             'ovs-vsctl clear port 4444 tag',
+             'ovs-vsctl remove port 4444 trunks 44',
+             'ovs-vsctl remove port 4444 trunks tag1',
+             'ovs-vsctl remove port 4444 trunks tag2'])
+
+    @mock.patch('networking_generic_switch.devices.netmiko_devices.'
+                'NetmikoSwitch.send_commands_to_device', autospec=True)
+    def test_plug_bond_to_network_subports(self, mock_exec):
+        trunk_details = {"sub_ports": [{"segmentation_id": "tag1"},
+                                       {"segmentation_id": "tag2"}]}
+        self.switch.plug_bond_to_network(4444, 44, trunk_details=trunk_details)
+        mock_exec.assert_called_with(
+            self.switch,
+            ['ovs-vsctl set port 4444 vlan_mode=native-untagged',
+             'ovs-vsctl set port 4444 tag=44',
+             'ovs-vsctl add port 4444 trunks 44',
+             'ovs-vsctl add port 4444 trunks tag1',
+             'ovs-vsctl add port 4444 trunks tag2'])
+
+    @mock.patch('networking_generic_switch.devices.netmiko_devices.'
+                'NetmikoSwitch.send_commands_to_device', autospec=True)
+    def test_unplug_bond_from_network_subports(self, mock_exec):
+        trunk_details = {"sub_ports": [{"segmentation_id": "tag1"},
+                                       {"segmentation_id": "tag2"}]}
+        self.switch.unplug_bond_from_network(
+            4444, 44, trunk_details=trunk_details)
+        mock_exec.assert_called_with(
+            self.switch,
+            ['ovs-vsctl clear port 4444 tag',
+             'ovs-vsctl clear port 4444 trunks',
+             'ovs-vsctl clear port 4444 vlan_mode',
+             'ovs-vsctl clear port 4444 vlan_mode',
+             'ovs-vsctl clear port 4444 tag',
+             'ovs-vsctl remove port 4444 trunks 44',
+             'ovs-vsctl remove port 4444 trunks tag1',
+             'ovs-vsctl remove port 4444 trunks tag2'])
+
+    @mock.patch('networking_generic_switch.devices.netmiko_devices.'
+                'NetmikoSwitch.send_commands_to_device', autospec=True)
+    def test_add_subports_on_trunk_no_subports(self, mock_exec):
+        port_id = uuidutils.generate_uuid()
+        parent_port = {
+            'binding:profile': {
+                'local_link_information': [
+                    {
+                        'switch_info': 'bar',
+                        'port_id': 2222
+                    }
+                ]},
+            'binding:vnic_type': 'baremetal',
+            'id': port_id
+        }
+        subports = []
+        self.switch.add_subports_on_trunk(parent_port, 44, subports=subports)
+        mock_exec.assert_called_with(self.switch, [])
+
+    @mock.patch('networking_generic_switch.devices.netmiko_devices.'
+                'NetmikoSwitch.send_commands_to_device', autospec=True)
+    def test_add_subports_on_trunk_subports(self, mock_exec):
+        port_id = uuidutils.generate_uuid()
+        parent_port = {
+            'binding:profile': {
+                'local_link_information': [
+                    {
+                        'switch_info': 'bar',
+                        'port_id': 2222
+                    }
+                ]},
+            'binding:vnic_type': 'baremetal',
+            'id': port_id
+        }
+        subports = [{"segmentation_id": "tag1"},
+                    {"segmentation_id": "tag2"}]
+        self.switch.add_subports_on_trunk(parent_port, 44, subports=subports)
+        mock_exec.assert_called_with(self.switch,
+                                     ['ovs-vsctl add port 44 trunks tag1',
+                                      'ovs-vsctl add port 44 trunks tag2'])
+
+    @mock.patch('networking_generic_switch.devices.netmiko_devices.'
+                'NetmikoSwitch.send_commands_to_device', autospec=True)
+    def test_del_subports_on_trunk_no_subports(self, mock_exec):
+        port_id = uuidutils.generate_uuid()
+        parent_port = {
+            'binding:profile': {
+                'local_link_information': [
+                    {
+                        'switch_info': 'bar',
+                        'port_id': 2222
+                    }
+                ]},
+            'binding:vnic_type': 'baremetal',
+            'id': port_id
+        }
+        subports = []
+        self.switch.del_subports_on_trunk(parent_port, 44, subports=subports)
+        mock_exec.assert_called_with(self.switch, [])
+
+    @mock.patch('networking_generic_switch.devices.netmiko_devices.'
+                'NetmikoSwitch.send_commands_to_device', autospec=True)
+    def test_del_subports_on_trunk_subports(self, mock_exec):
+        port_id = uuidutils.generate_uuid()
+        parent_port = {
+            'binding:profile': {
+                'local_link_information': [
+                    {
+                        'switch_info': 'bar',
+                        'port_id': 2222
+                    }
+                ]},
+            'binding:vnic_type': 'baremetal',
+            'id': port_id
+        }
+        subports = [{"segmentation_id": "tag1"},
+                    {"segmentation_id": "tag2"}]
+        self.switch.del_subports_on_trunk(parent_port, 44, subports=subports)
+        mock_exec.assert_called_with(self.switch,
+                                     ['ovs-vsctl remove port 44 trunks tag1',
+                                      'ovs-vsctl remove port 44 trunks tag2'])
 
     def test__format_commands(self):
         cmd_set = self.switch._format_commands(

--- a/networking_generic_switch/tests/unit/test_generic_switch_mech.py
+++ b/networking_generic_switch/tests/unit/test_generic_switch_mech.py
@@ -19,7 +19,9 @@ from unittest import mock
 from neutron.db import provisioning_blocks
 from neutron.plugins.ml2 import driver_context
 from neutron_lib.callbacks import resources
+from neutron_lib.plugins import directory
 
+from networking_generic_switch.devices import utils as device_utils
 from networking_generic_switch import exceptions
 from networking_generic_switch import generic_switch_mech as gsm
 
@@ -34,6 +36,8 @@ class TestGenericSwitchDriver(unittest.TestCase):
         self.switch_mock.config = {'device_type': 'bar', 'spam': 'ham',
                                    'ip': 'ip'}
         self.switch_mock._get_physical_networks.return_value = []
+        self.ctxt = mock.MagicMock()
+        self.db = mock.MagicMock()
         patcher = mock.patch(
             'networking_generic_switch.devices.device_manager',
             return_value=self.switch_mock)
@@ -867,7 +871,94 @@ class TestGenericSwitchDriver(unittest.TestCase):
         self.switch_mock.delete_port.assert_called_once_with(2222, 123)
         m_pc.assert_not_called()
 
-    @mock.patch.object(provisioning_blocks, 'provisioning_complete')
+    @mock.patch.object(provisioning_blocks, 'provisioning_complete',
+                       autospec=True)
+    def test_update_port_postcommit_trunk_not_supported(self, m_pc, m_list):
+        driver = gsm.GenericSwitchDriver()
+        driver.initialize()
+        mock_context = mock.create_autospec(driver_context.PortContext)
+        mock_context._plugin_context = mock.MagicMock()
+        mock_context._plugin = mock.MagicMock()
+        mock_context.current = {'binding:profile':
+                                {'local_link_information':
+                                    [
+                                        {
+                                            'switch_info': 'foo',
+                                            'port_id': 2222
+                                        }
+                                    ]
+                                 },
+                                'binding:vnic_type': 'baremetal',
+                                'id': '123',
+                                'binding:vif_type': 'other',
+                                'status': 'DOWN',
+                                'trunk_details': {
+                                    'sub_ports': [
+                                        {'segmentation_id': 1234,
+                                         'port_id': 's1'}
+                                    ]
+                                }}
+        mock_context.original = {'binding:profile': {},
+                                 'binding:vnic_type': 'baremetal',
+                                 'id': '123',
+                                 'binding:vif_type': 'unbound'}
+
+        mock_context.top_bound_segment = {'physical_network': 'physnet1',
+                                          'network_id': 'aaaa-bbbb-ccc',
+                                          'segmentation_id': 123}
+        self.switch_mock._get_physical_networks.return_value = ['physnet1']
+        self.switch_mock.support_trunk_on_bond_ports = False
+        self.switch_mock.support_trunk_on_ports = False
+
+        with self.assertRaises(exceptions.GenericSwitchNotSupported):
+            driver.update_port_postcommit(mock_context)
+        self.switch_mock.plug_port_to_network.assert_not_called()
+        m_pc.assert_not_called()
+
+    @mock.patch.object(provisioning_blocks, 'provisioning_complete',
+                       autospec=True)
+    def test_update_port_postcommit_trunk(self, m_pc, m_list):
+        driver = gsm.GenericSwitchDriver()
+        driver.initialize()
+        mock_context = mock.create_autospec(driver_context.PortContext)
+        mock_context._plugin_context = mock.MagicMock()
+        mock_context._plugin = mock.MagicMock()
+        mock_context.current = {'binding:profile':
+                                {'local_link_information':
+                                    [
+                                        {
+                                            'switch_info': 'foo',
+                                            'port_id': 2222
+                                        }
+                                    ]
+                                 },
+                                'binding:vnic_type': 'baremetal',
+                                'id': '123',
+                                'binding:vif_type': 'other',
+                                'status': 'DOWN',
+                                'trunk_details': {
+                                    'sub_ports': [
+                                        {'segmentation_id': 1234,
+                                         'port_id': 's1'}
+                                    ]
+                                }}
+        mock_context.original = {'binding:profile': {},
+                                 'binding:vnic_type': 'baremetal',
+                                 'id': '123',
+                                 'binding:vif_type': 'unbound'}
+        mock_context.top_bound_segment = {'physical_network': 'physnet1',
+                                          'network_id': 'aaaa-bbbb-ccc',
+                                          'segmentation_id': 123}
+        self.switch_mock._get_physical_networks.return_value = ['physnet1']
+        self.switch_mock.support_trunk_on_bond_ports = True
+        self.switch_mock.support_trunk_on_ports = True
+
+        driver.update_port_postcommit(mock_context)
+        self.switch_mock.plug_port_to_network.assert_called_once()
+        m_pc.assert_called_once()
+
+    @mock.patch.object(provisioning_blocks, 'provisioning_complete',
+                       autospec=True)
     def test_update_portgroup_postcommit_unbind(self, m_pc, m_list):
         driver = gsm.GenericSwitchDriver()
         driver.initialize()
@@ -1172,6 +1263,200 @@ class TestGenericSwitchDriver(unittest.TestCase):
         self.switch_mock.plug_port_to_network.assert_not_called()
         self.assertFalse(m_apc.called)
 
+    @mock.patch.object(provisioning_blocks, 'add_provisioning_component',
+                       autospec=True)
+    def test_bind_port_unknown_switch(self, m_apc, m_list):
+        driver = gsm.GenericSwitchDriver()
+        driver.initialize()
+        mock_context = mock.create_autospec(driver_context.PortContext)
+        mock_context._plugin_context = mock.MagicMock()
+        mock_context.current = {'binding:profile':
+                                {'local_link_information':
+                                    [
+                                        {
+                                            'switch_info': 'bar',
+                                            'port_id': 2222
+                                        }
+                                    ]},
+                                'binding:vnic_type': 'baremetal',
+                                'id': '123'}
+        mock_context.network.current = {
+            'provider:physical_network': 'physnet1'
+        }
+        mock_context.segments_to_bind = [
+            {
+                'segmentation_id': None,
+                'id': 123
+            }
+        ]
+        self.assertIsNone(driver.bind_port(mock_context))
+        self.assertFalse(mock_context.set_binding.called)
+        self.switch_mock.plug_port_to_network.assert_not_called()
+        self.assertFalse(m_apc.called)
+
+    @mock.patch.object(provisioning_blocks, 'add_provisioning_component',
+                       autospec=True)
+    def test_bind_port_with_different_physnet(self, m_apc, m_list):
+        driver = gsm.GenericSwitchDriver()
+        driver.initialize()
+        mock_context = mock.create_autospec(driver_context.PortContext)
+        mock_context._plugin_context = mock.MagicMock()
+        mock_context.current = {'binding:profile':
+                                {'local_link_information':
+                                    [
+                                        {
+                                            'switch_info': 'bar',
+                                            'port_id': 2222
+                                        }
+                                    ]},
+                                'binding:vnic_type': 'baremetal',
+                                'id': '123'}
+        mock_context.network.current = {
+            'provider:physical_network': 'physnet1'
+        }
+        mock_context.segments_to_bind = [
+            {
+                'segmentation_id': None,
+                'id': 123
+            }
+        ]
+        self.switch_mock._get_physical_networks.return_value = ['physnet2']
+        self.assertIsNone(driver.bind_port(mock_context))
+        self.assertFalse(mock_context.set_binding.called)
+        self.switch_mock.plug_port_to_network.assert_not_called()
+        self.assertFalse(m_apc.called)
+
+    @mock.patch.object(directory, "get_plugin", autospec=True)
+    @mock.patch.object(device_utils, "get_switch_device", autospec=True)
+    def test_subports_added_other_port(self, mock_get_switch, mock_plugin,
+                                       m_list):
+        driver = gsm.GenericSwitchDriver()
+        driver.initialize()
+
+        parent_port = {
+            'binding:profile': {
+                'local_link_information': [
+                    {
+                        'switch_info': 'bar',
+                        'port_id': 2222
+                    }
+                ]},
+            'binding:vnic_type': 'baremetal',
+            'id': '123'
+        }
+        subports = [{"segmentation_id": "tag1", "port_id": "s1"},
+                    {"segmentation_id": "tag2", "port_id": "s2"}]
+
+        mock_plugin.return_value = mock.MagicMock()
+        mock_plugin.return_value.get_port.return_value = {"status": "DOWN"}
+
+        driver.subports_added(self.ctxt, parent_port, subports=subports)
+        mock_get_switch.return_value.add_subports_on_trunk.assart_not_called()
+
+    @mock.patch.object(device_utils, "get_switch_device", autospec=True)
+    def test_subports_added_no_llc(self, mock_get_switch, m_list):
+        driver = gsm.GenericSwitchDriver()
+        driver.initialize()
+
+        parent_port = {
+            'binding:profile': {},
+            'binding:vnic_type': 'baremetal',
+            'id': '123'
+        }
+        subports = [{"segmentation_id": "tag1"},
+                    {"segmentation_id": "tag2"}]
+
+        driver.subports_added(self.ctxt, parent_port, subports=subports)
+        mock_get_switch.return_value.add_subports_on_trunk.assart_not_called()
+
+    @mock.patch.object(directory, "get_plugin", autospec=True)
+    @mock.patch.object(device_utils, "get_switch_device", autospec=True)
+    def test_subports_added(self, mock_get_switch, mock_plugin, m_list):
+        driver = gsm.GenericSwitchDriver()
+        driver.initialize()
+
+        parent_port = {
+            'binding:profile': {
+                'local_link_information': [
+                    {
+                        'switch_info': 'bar',
+                        'port_id': 2222
+                    }
+                ]},
+            'binding:vnic_type': 'baremetal',
+            'id': '123'
+        }
+        subports = [{"segmentation_id": "tag1", "port_id": "s1"},
+                    {"segmentation_id": "tag2", "port_id": "s2"}]
+
+        mock_plugin.return_value = mock.MagicMock()
+        mock_plugin.return_value.get_port.return_value = {"status": "DOWN"}
+
+        driver.subports_added(self.ctxt, parent_port, subports=subports)
+        mock_get_switch.return_value.add_subports_on_trunk.assert_has_calls(
+            [mock.call(parent_port['binding:profile'], 2222, subports)])
+
+    @mock.patch.object(device_utils, "get_switch_device", autospec=True)
+    def test_subports_deleted_other_port(self, mock_get_switch, m_list):
+        driver = gsm.GenericSwitchDriver()
+        driver.initialize()
+
+        parent_port = {
+            'binding:profile': {
+                'local_link_information': [
+                    {
+                        'switch_info': 'bar',
+                        'port_id': 2222
+                    }
+                ]},
+            'binding:vnic_type': 'baremetal',
+            'id': '123'
+        }
+        subports = [{"segmentation_id": "tag1"},
+                    {"segmentation_id": "tag2"}]
+
+        driver.subports_deleted(self.ctxt, parent_port, subports=subports)
+        mock_get_switch.return_value.del_subports_on_trunk.assart_not_called()
+
+    @mock.patch.object(device_utils, "get_switch_device", autospec=True)
+    def test_subports_deleted_no_llc(self, mock_get_switch, m_list):
+        driver = gsm.GenericSwitchDriver()
+        driver.initialize()
+
+        parent_port = {
+            'binding:profile': {},
+            'binding:vnic_type': 'baremetal',
+            'id': '123'
+        }
+        subports = [{"segmentation_id": "tag1"},
+                    {"segmentation_id": "tag2"}]
+
+        driver.subports_deleted(self.ctxt, parent_port, subports=subports)
+        mock_get_switch.return_value.del_subports_on_trunk.assart_not_called()
+
+    @mock.patch.object(device_utils, "get_switch_device", autospec=True)
+    def test_subports_deleted(self, mock_get_switch, m_list):
+        driver = gsm.GenericSwitchDriver()
+        driver.initialize()
+
+        parent_port = {
+            'binding:profile': {
+                'local_link_information': [
+                    {
+                        'switch_info': 'bar',
+                        'port_id': 2222
+                    }
+                ]},
+            'binding:vnic_type': 'baremetal',
+            'id': '123'
+        }
+        subports = [{"segmentation_id": "tag1"},
+                    {"segmentation_id": "tag2"}]
+
+        driver.subports_deleted(self.ctxt, parent_port, subports=subports)
+        mock_get_switch.return_value.del_subports_on_trunk.assert_has_calls(
+            [mock.call(parent_port['binding:profile'], 2222, subports)])
+
     def test_empty_methods(self, m_list):
         driver = gsm.GenericSwitchDriver()
         driver.initialize()
@@ -1196,34 +1481,3 @@ class TestGenericSwitchDriver(unittest.TestCase):
         driver.create_port_postcommit(mock_context)
         driver.update_port_precommit(mock_context)
         driver.delete_port_precommit(mock_context)
-
-
-class TestGenericSwitchDriverStaticMethods(unittest.TestCase):
-
-    def test__is_802_3ad_no_lgi(self):
-        driver = gsm.GenericSwitchDriver()
-        port = {'binding:profile': {}}
-        self.assertFalse(driver._is_802_3ad(port))
-
-    def test__is_802_3ad_no_bond_mode(self):
-        driver = gsm.GenericSwitchDriver()
-        port = {'binding:profile': {'local_group_information': {}}}
-        self.assertFalse(driver._is_802_3ad(port))
-
-    def test__is_802_3ad_wrong_bond_mode(self):
-        driver = gsm.GenericSwitchDriver()
-        port = {'binding:profile': {'local_group_information':
-                {'bond_mode': 42}}}
-        self.assertFalse(driver._is_802_3ad(port))
-
-    def test__is_802_3ad_numeric(self):
-        driver = gsm.GenericSwitchDriver()
-        port = {'binding:profile': {'local_group_information':
-                {'bond_mode': '4'}}}
-        self.assertTrue(driver._is_802_3ad(port))
-
-    def test__is_802_3ad_string(self):
-        driver = gsm.GenericSwitchDriver()
-        port = {'binding:profile': {'local_group_information':
-                {'bond_mode': '802.3ad'}}}
-        self.assertTrue(driver._is_802_3ad(port))

--- a/networking_generic_switch/trunk_driver.py
+++ b/networking_generic_switch/trunk_driver.py
@@ -1,0 +1,109 @@
+# Copyright 2024 StackHPC Ltd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from neutron.objects.ports import Port
+from neutron.services.trunk.drivers import base as trunk_base
+from neutron_lib.api.definitions import portbindings
+from neutron_lib.callbacks import events
+from neutron_lib.callbacks import registry
+from neutron_lib.callbacks import resources
+from neutron_lib import context as n_context
+from neutron_lib.db import api as db_api
+from neutron_lib.plugins import directory
+from neutron_lib.services.trunk import constants as trunk_consts
+from oslo_config import cfg
+from oslo_log import log as logging
+
+LOG = logging.getLogger(__name__)
+
+MECH_DRIVER_NAME = 'genericswitch'
+
+SUPPORTED_INTERFACES = (
+    portbindings.VIF_TYPE_OTHER,
+    portbindings.VIF_TYPE_VHOST_USER,
+)
+
+SUPPORTED_SEGMENTATION_TYPES = (
+    trunk_consts.SEGMENTATION_TYPE_VLAN,
+)
+
+
+class GenericSwitchTrunkDriver(trunk_base.DriverBase):
+    @property
+    def is_loaded(self):
+        try:
+            return (MECH_DRIVER_NAME in
+                    cfg.CONF.ml2.mechanism_drivers)
+        except cfg.NoSuchOptError:
+            return False
+
+    @registry.receives(resources.TRUNK_PLUGIN, [events.AFTER_INIT])
+    def register(self, resource, event, trigger, payload=None):
+        super(GenericSwitchTrunkDriver, self).register(
+            resource, event, trigger, payload=payload)
+        self._handler = GenericSwitchTrunkHandler(self.plugin_driver)
+        registry.subscribe(
+            self._handler.subports_added,
+            resources.SUBPORTS,
+            events.AFTER_CREATE)
+        registry.subscribe(
+            self._handler.subports_deleted,
+            resources.SUBPORTS,
+            events.AFTER_DELETE)
+
+    @classmethod
+    def create(cls, plugin_driver):
+        cls.plugin_driver = plugin_driver
+        return cls(MECH_DRIVER_NAME,
+                   SUPPORTED_INTERFACES,
+                   SUPPORTED_SEGMENTATION_TYPES,
+                   None,
+                   can_trunk_bound_port=True)
+
+
+class GenericSwitchTrunkHandler(object):
+    def __init__(self, plugin_driver):
+        self.plugin_driver = plugin_driver
+        self.core_plugin = directory.get_plugin()
+
+    def subports_added(self, resource, event, trunk_plugin, payload):
+        trunk = payload.states[0]
+        subports = payload.metadata['subports']
+        LOG.debug("GenericSwitch: subports added %s to trunk %s",
+                  subports, trunk)
+        context = n_context.get_admin_context()
+        with db_api.CONTEXT_READER.using(context):
+            parent_port = Port.get_object(context, id=trunk.port_id)
+
+            parent_port_obj = self.core_plugin._make_port_dict(parent_port)
+
+            self.plugin_driver.subports_added(
+                context,
+                parent_port_obj,
+                subports)
+
+    def subports_deleted(self, resource, event, trunk_plugin, payload):
+        trunk = payload.states[0]
+        subports = payload.metadata['subports']
+        LOG.debug("GenericSwitch: subports deleted %s from trunk %s",
+                  subports, trunk)
+        context = n_context.get_admin_context()
+        with db_api.CONTEXT_READER.using(context):
+            parent_port = Port.get_object(context, id=trunk.port_id)
+
+            parent_port_obj = self.core_plugin._make_port_dict(parent_port)
+            self.plugin_driver.subports_deleted(
+                context,
+                parent_port_obj,
+                subports)

--- a/networking_generic_switch/utils.py
+++ b/networking_generic_switch/utils.py
@@ -1,0 +1,27 @@
+# Copyright 2025 Mirantis, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+def is_802_3ad(binding_profile):
+    """Return whether a port binding profile is using 802.3ad link aggregation.
+
+    :param binding_profile: The port binding_profile to check
+    :returns: Whether the port is a port group using 802.3ad link
+              aggregation.
+    """
+    binding_profile = binding_profile or {}
+    local_group_information = binding_profile.get(
+        'local_group_information')
+    if not local_group_information:
+        return False
+    return local_group_information.get('bond_mode') in ['4', '802.3ad']

--- a/releasenotes/notes/vlan-aware-vms-3923cc17254829e9.yaml
+++ b/releasenotes/notes/vlan-aware-vms-3923cc17254829e9.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Add support of VLAN aware instances for the following drivers
+      * OVS (as reference implementation)
+      * AristaEos
+      * CiscoIos


### PR DESCRIPTION
With this patch ngs starts supporting attaching of trunk port to baremetal server. Only VLAN Neutron network is supported.

Closes-Bug: #1653968

Co-Authored-By: Vasyl Saienko <vsaienko@mirantis.com>
Co-Authored-By: Will Szumski <will@stackhpc.com>
Co-Authored-By: Mark Goddard <mark@stackhpc.com>
Co-Authored-By: Seunghun Lee <seunghun@stackhpc.com>

Depends-On: https://review.opendev.org/c/openstack/ironic/+/941023

Change-Id: I978cb6b1ea8c049b40aaf1b305d0d0f033282299