### PR TITLE
Revert old trunking patches

### DIFF
--- a/networking_generic_switch/devices/__init__.py
+++ b/networking_generic_switch/devices/__init__.py
@@ -46,7 +46,6 @@ NGS_INTERNAL_OPTS = [
     {'name': 'ngs_network_name_format', 'default': '{network_id}'},
     # If false, ngs will not add and delete VLANs from switches
     {'name': 'ngs_manage_vlans', 'default': True},
-    {'name': 'vlan_translation_supported', 'default': False},
     # If False, ngs will skip saving configuration on devices
     {'name': 'ngs_save_configuration', 'default': True},
     # When true try to batch up in flight switch requests
@@ -221,10 +220,6 @@ class GenericSwitchDevice(object, metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def del_network(self, segmentation_id, network_id):
-        pass
-
-    def plug_port_to_network_trunk(self, port_id, segmentation_id,
-                                   trunk_details=None, vtr=False):
         pass
 
     @abc.abstractmethod

--- a/networking_generic_switch/devices/netmiko_devices/__init__.py
+++ b/networking_generic_switch/devices/netmiko_devices/__init__.py
@@ -97,10 +97,6 @@ class NetmikoSwitch(devices.GenericSwitchDevice):
 
     SAVE_CONFIGURATION = None
 
-    SET_NATIVE_VLAN = None
-
-    ALLOW_NETWORK_ON_TRUNK = None
-
     ERROR_MSG_PATTERNS = ()
     """Sequence of error message patterns.
 
@@ -287,28 +283,6 @@ class NetmikoSwitch(devices.GenericSwitchDevice):
                                       network_name=network_name)
         return self.send_commands_to_device(cmds)
 
-    @check_output('plug port trunk')
-    def plug_port_to_network_trunk(self, port, segmentation_id,
-                                   trunk_details=None, vtr=False):
-        cmd_set = []
-        vts = self.ngs_config.get('vlan_translation_supported', False)
-        # NOTE(vsaienko) Always use vlan translation if it is supported.
-        if vts:
-            cmd_set.extend(self.get_trunk_port_cmds_vlan_translation(
-                port, segmentation_id, trunk_details))
-        else:
-            if vtr:
-                msg = ("Cannot bind_port VLAN aware port as switch %s "
-                       "doesn't support VLAN translation. "
-                       "But it is required.") % self.config['ip']
-                raise exc.GenericSwitchNotSupported(error=msg)
-            else:
-                cmd_set.extend(
-                    self.get_trunk_port_cmds_no_vlan_translation(
-                        port, segmentation_id, trunk_details))
-
-        self.send_commands_to_device(cmd_set)
-
     @check_output('plug port')
     def plug_port_to_network(self, port, segmentation_id):
         cmds = []
@@ -450,22 +424,3 @@ class NetmikoSwitch(devices.GenericSwitchDevice):
                 raise exc.GenericSwitchNetmikoConfigError(
                     config=device_utils.sanitise_config(self.config),
                     error=msg)
-
-    def get_trunk_port_cmds_no_vlan_translation(self, port_id,
-                                                segmentation_id,
-                                                trunk_details):
-        cmd_set = []
-        cmd_set.extend(
-            self._format_commands(self.SET_NATIVE_VLAN,
-                                  port=port_id,
-                                  segmentation_id=segmentation_id))
-        for sub_port in trunk_details.get('sub_ports'):
-            cmd_set.extend(
-                self._format_commands(
-                    self.ALLOW_NETWORK_ON_TRUNK, port=port_id,
-                    segmentation_id=sub_port['segmentation_id']))
-        return cmd_set
-
-    def get_trunk_port_cmds_vlan_translation(self, port_id, segmentation_id,
-                                             trunk_details):
-        pass

--- a/networking_generic_switch/devices/netmiko_devices/arista.py
+++ b/networking_generic_switch/devices/netmiko_devices/arista.py
@@ -37,15 +37,3 @@ class AristaEos(netmiko_devices.NetmikoSwitch):
         'no switchport mode trunk',
         'switchport trunk allowed vlan none'
     )
-
-    SET_NATIVE_VLAN = (
-        'interface {port}',
-        'switchport mode trunk',
-        'switchport trunk native vlan {segmentation_id}',
-        'switchport trunk allowed vlan add {segmentation_id}'
-    )
-
-    ALLOW_NETWORK_ON_TRUNK = (
-        'interface {port}',
-        'switchport trunk allowed vlan add {segmentation_id}'
-    )

--- a/networking_generic_switch/devices/netmiko_devices/cisco.py
+++ b/networking_generic_switch/devices/netmiko_devices/cisco.py
@@ -39,18 +39,6 @@ class CiscoIos(netmiko_devices.NetmikoSwitch):
         'switchport trunk allowed vlan none'
     )
 
-    SET_NATIVE_VLAN = (
-        'interface {port}',
-        'switchport mode trunk',
-        'switchport trunk native vlan {segmentation_id}',
-        'switchport trunk allowed vlan add {segmentation_id}'
-    )
-
-    ALLOW_NETWORK_ON_TRUNK = (
-        'interface {port}',
-        'switchport trunk allowed vlan add {segmentation_id}'
-    )
-
 
 class CiscoNxOS(netmiko_devices.NetmikoSwitch):
     """Netmiko device driver for Cisco Nexus switches running NX-OS."""

--- a/networking_generic_switch/devices/netmiko_devices/cumulus.py
+++ b/networking_generic_switch/devices/netmiko_devices/cumulus.py
@@ -117,8 +117,6 @@ class CumulusNVUE(netmiko_devices.NetmikoSwitch):
     ]
 
     PLUG_PORT_TO_NETWORK = [
-        'nv unset interface {port} bridge domain br_default vlan',
-        'nv unset interface {port} bridge domain br_default untagged',
         'nv set interface {port} bridge domain br_default access '
         '{segmentation_id}',
     ]
@@ -137,18 +135,6 @@ class CumulusNVUE(netmiko_devices.NetmikoSwitch):
 
     SAVE_CONFIGURATION = [
         'nv config save',
-    ]
-
-    SET_NATIVE_VLAN = [
-        'nv unset interface {port} bridge domain br_default access',
-        'nv set interface {port} bridge domain br_default untagged '
-        '{segmentation_id}',
-        'nv set interface {port} bridge domain br_default vlan '
-        '{segmentation_id}'
-    ]
-    ALLOW_NETWORK_ON_TRUNK = [
-        'nv set interface {port} bridge domain br_default vlan '
-        '{segmentation_id}'
     ]
 
     ERROR_MSG_PATTERNS = [

--- a/networking_generic_switch/devices/netmiko_devices/dell.py
+++ b/networking_generic_switch/devices/netmiko_devices/dell.py
@@ -70,19 +70,6 @@ class DellOS10(netmiko_devices.NetmikoSwitch):
         "exit",
     )
 
-    SET_NATIVE_VLAN = (
-        'interface {port}',
-        # Clean all the old trunked vlans by switching to access mode first
-        'switchport mode access',
-        'switchport mode trunk',
-        'switchport access vlan {segmentation_id}',
-    )
-
-    ALLOW_NETWORK_ON_TRUNK = (
-        'interface {port}',
-        'switchport trunk allowed vlan {segmentation_id}'
-    )
-
     ERROR_MSG_PATTERNS = ()
     """Sequence of error message patterns.
 

--- a/networking_generic_switch/exceptions.py
+++ b/networking_generic_switch/exceptions.py
@@ -53,8 +53,3 @@ class GenericSwitchNetmikoConfigError(GenericSwitchException):
 
 class GenericSwitchBatchError(GenericSwitchException):
     message = _("Batching error: %(device)s, error: %(error)s")
-
-
-class GenericSwitchNotSupported(GenericSwitchException):
-    message = _("Requested feature is not supported by "
-                "networking-generic-switch. %(error)s")

--- a/networking_generic_switch/generic_switch_mech.py
+++ b/networking_generic_switch/generic_switch_mech.py
@@ -24,7 +24,6 @@ from oslo_log import log as logging
 from networking_generic_switch import config as gsw_conf
 from networking_generic_switch import devices
 from networking_generic_switch.devices import utils as device_utils
-from networking_generic_switch import exceptions as ngs_exc
 
 LOG = logging.getLogger(__name__)
 
@@ -372,35 +371,15 @@ class GenericSwitchDriver(api.MechanismDriver):
 
                 # If segmentation ID is None, set vlan 1
                 segmentation_id = segment.get(api.SEGMENTATION_ID) or 1
-                trunk_details = port.get('trunk_details', {})
                 LOG.debug("Putting switch port %(switch_port)s on "
                           "%(switch_info)s in vlan %(segmentation_id)s",
                           {'switch_port': port_id, 'switch_info': switch_info,
                            'segmentation_id': segmentation_id})
                 # Move port to network
-                try:
-                    if trunk_details:
-                        vtr = self._is_vlan_translation_required(trunk_details)
-                        switch.plug_port_to_network_trunk(
-                            port_id, segmentation_id, trunk_details, vtr)
-                    elif is_802_3ad:
-                        switch.plug_bond_to_network(port_id, segmentation_id)
-                    else:
-                        switch.plug_port_to_network(port_id, segmentation_id)
-                except ngs_exc.GenericSwitchNotSupported as e:
-                    LOG.warning("Operation is not supported by "
-                                "networking-generic-switch. %(err)s)",
-                                {'err': e})
-                    raise e
-                except Exception as e:
-                    LOG.error("Failed to plug port %(port_id)s in "
-                              "segment %(segment_id)s on device "
-                              "%(device)s due to error %(err)s",
-                              {'port_id': port['id'],
-                               'device': switch_info,
-                               'segment_id': segmentation_id,
-                               'err': e})
-                    raise e
+                if is_802_3ad:
+                    switch.plug_bond_to_network(port_id, segmentation_id)
+                else:
+                    switch.plug_port_to_network(port_id, segmentation_id)
                 LOG.info("Successfully plugged port %(port_id)s in segment "
                          "%(segment_id)s on device %(device)s",
                          {'port_id': port['id'], 'device': switch_info,
@@ -444,14 +423,6 @@ class GenericSwitchDriver(api.MechanismDriver):
         port = context.current
         if self._is_port_bound(port):
             self._unplug_port_from_segment(port, context.top_bound_segment)
-
-    def _is_vlan_translation_required(self, trunk_details):
-        """Check if vlan translation is required to configure specific trunk.
-
-        :returns: True if vlan translation is required, False otherwise.
-        """
-        # FIXME: removed for simplicity
-        return False
 
     def bind_port(self, context):
         """Attempt to bind a port.

--- a/networking_generic_switch/tests/unit/netmiko/test_arista_eos.py
+++ b/networking_generic_switch/tests/unit/netmiko/test_arista_eos.py
@@ -14,8 +14,6 @@
 
 from unittest import mock
 
-from neutron.plugins.ml2 import driver_context
-
 from networking_generic_switch.devices.netmiko_devices import arista
 from networking_generic_switch.tests.unit.netmiko import test_netmiko_base
 
@@ -61,43 +59,6 @@ class TestNetmikoAristaEos(test_netmiko_base.NetmikoSwitchTestBase):
             ['interface 3333', 'no switchport access vlan 33',
              'no switchport mode trunk',
              'switchport trunk allowed vlan none'])
-
-    def test_get_trunk_port_cmds_no_vlan_translation(self):
-        mock_context = mock.create_autospec(driver_context.PortContext)
-        self.switch.ngs_config['vlan_translation_supported'] = False
-        trunk_details = {'trunk_id': 'aaa-bbb-ccc-ddd',
-                         'sub_ports': [{'segmentation_id': 130,
-                                        'port_id': 'aaa-bbb-ccc-ddd',
-                                        'segmentation_type': 'vlan',
-                                        'mac_address': u'fa:16:3e:1c:c2:7e'}]}
-        mock_context.current = {'binding:profile':
-                                {'local_link_information':
-                                    [
-                                        {
-                                            'switch_info': 'foo',
-                                            'port_id': '2222'
-                                        }
-                                    ]
-                                 },
-                                'binding:vnic_type': 'baremetal',
-                                'id': 'aaaa-bbbb-cccc',
-                                'trunk_details': trunk_details}
-        mock_context.network = mock.Mock()
-        mock_context.network.current = {'provider:segmentation_id': 123}
-        mock_context.segments_to_bind = [
-            {
-                'segmentation_id': 777,
-                'id': 123
-            }
-        ]
-        res = self.switch.get_trunk_port_cmds_no_vlan_translation(
-            '2222', 777, trunk_details)
-        self.assertEqual(['interface 2222', 'switchport mode trunk',
-                          'switchport trunk native vlan 777',
-                          'switchport trunk allowed vlan add 777',
-                          'interface 2222',
-                          'switchport trunk allowed vlan add 130'],
-                         res)
 
     def test__format_commands(self):
         cmd_set = self.switch._format_commands(

--- a/networking_generic_switch/tests/unit/netmiko/test_cisco_ios.py
+++ b/networking_generic_switch/tests/unit/netmiko/test_cisco_ios.py
@@ -14,8 +14,6 @@
 
 from unittest import mock
 
-from neutron.plugins.ml2 import driver_context
-
 from networking_generic_switch.devices.netmiko_devices import cisco
 from networking_generic_switch.tests.unit.netmiko import test_netmiko_base
 
@@ -60,43 +58,6 @@ class TestNetmikoCiscoIos(test_netmiko_base.NetmikoSwitchTestBase):
             self.switch,
             ['interface 3333', 'no switchport access vlan 33',
              'no switchport mode trunk', 'switchport trunk allowed vlan none'])
-
-    def test_get_trunk_port_cmds_no_vlan_translation(self):
-        mock_context = mock.create_autospec(driver_context.PortContext)
-        self.switch.ngs_config['vlan_translation_supported'] = True
-        trunk_details = {'trunk_id': 'aaa-bbb-ccc-ddd',
-                         'sub_ports': [{'segmentation_id': 130,
-                                        'port_id': 'aaa-bbb-ccc-ddd',
-                                        'segmentation_type': 'vlan',
-                                        'mac_address': u'fa:16:3e:1c:c2:7e'}]}
-        mock_context.current = {'binding:profile':
-                                {'local_link_information':
-                                    [
-                                        {
-                                            'switch_info': 'foo',
-                                            'port_id': '2222'
-                                        }
-                                    ]
-                                 },
-                                'binding:vnic_type': 'baremetal',
-                                'id': 'aaaa-bbbb-cccc',
-                                'trunk_details': trunk_details}
-        mock_context.network = mock.Mock()
-        mock_context.network.current = {'provider:segmentation_id': 123}
-        mock_context.segments_to_bind = [
-            {
-                'segmentation_id': 777,
-                'id': 123
-            }
-        ]
-        res = self.switch.get_trunk_port_cmds_no_vlan_translation(
-            '2222', 777, trunk_details)
-        self.assertEqual(['interface 2222', 'switchport mode trunk',
-                          'switchport trunk native vlan 777',
-                          'switchport trunk allowed vlan add 777',
-                          'interface 2222',
-                          'switchport trunk allowed vlan add 130'],
-                         res)
 
     def test__format_commands(self):
         cmd_set = self.switch._format_commands(

--- a/networking_generic_switch/tests/unit/netmiko/test_cumulus_nvue.py
+++ b/networking_generic_switch/tests/unit/netmiko/test_cumulus_nvue.py
@@ -57,8 +57,6 @@ class TestNetmikoCumulusNVUE(test_netmiko_base.NetmikoSwitchTestBase):
             self.switch,
             ['nv set interface 3333 link state up',
              'nv unset interface 3333 bridge domain br_default access',
-             'nv unset interface 3333 bridge domain br_default vlan',
-             'nv unset interface 3333 bridge domain br_default untagged',
              'nv set interface 3333 bridge domain br_default access 33'])
 
     @mock.patch('networking_generic_switch.devices.netmiko_devices.'
@@ -91,9 +89,7 @@ class TestNetmikoCumulusNVUE(test_netmiko_base.NetmikoSwitchTestBase):
         switch.plug_port_to_network(3333, 33)
         mock_exec.assert_called_with(
             switch,
-            ['nv unset interface 3333 bridge domain br_default vlan',
-             'nv unset interface 3333 bridge domain br_default untagged',
-             'nv set interface 3333 bridge domain br_default access 33'])
+            ['nv set interface 3333 bridge domain br_default access 33'])
 
     @mock.patch('networking_generic_switch.devices.netmiko_devices.'
                 'NetmikoSwitch.send_commands_to_device',
@@ -104,8 +100,6 @@ class TestNetmikoCumulusNVUE(test_netmiko_base.NetmikoSwitchTestBase):
             self.switch,
             ['nv unset interface 3333 bridge domain br_default access',
              'nv set bridge domain br_default vlan 123',
-             'nv unset interface 3333 bridge domain br_default vlan',
-             'nv unset interface 3333 bridge domain br_default untagged',
              'nv set interface 3333 bridge domain br_default access 123',
              'nv set interface 3333 link state down'])
 
@@ -131,8 +125,6 @@ class TestNetmikoCumulusNVUE(test_netmiko_base.NetmikoSwitchTestBase):
             self.switch,
             ['nv set interface 3333 link state up',
              'nv unset interface 3333 bridge domain br_default access',
-             'nv unset interface 3333 bridge domain br_default vlan',
-             'nv unset interface 3333 bridge domain br_default untagged',
              'nv set interface 3333 bridge domain br_default access 33'])
 
     @mock.patch('networking_generic_switch.devices.netmiko_devices.'
@@ -146,9 +138,7 @@ class TestNetmikoCumulusNVUE(test_netmiko_base.NetmikoSwitchTestBase):
         switch.plug_bond_to_network(3333, 33)
         mock_exec.assert_called_with(
             switch,
-            ['nv unset interface 3333 bridge domain br_default vlan',
-             'nv unset interface 3333 bridge domain br_default untagged',
-             'nv set interface 3333 bridge domain br_default access 33'])
+            ['nv set interface 3333 bridge domain br_default access 33'])
 
     @mock.patch('networking_generic_switch.devices.netmiko_devices.'
                 'NetmikoSwitch.send_commands_to_device',
@@ -159,8 +149,6 @@ class TestNetmikoCumulusNVUE(test_netmiko_base.NetmikoSwitchTestBase):
             self.switch,
             ['nv unset interface 3333 bridge domain br_default access',
              'nv set bridge domain br_default vlan 123',
-             'nv unset interface 3333 bridge domain br_default vlan',
-             'nv unset interface 3333 bridge domain br_default untagged',
              'nv set interface 3333 bridge domain br_default access 123',
              'nv set interface 3333 link state down'])
 

--- a/networking_generic_switch/tests/unit/netmiko/test_dell.py
+++ b/networking_generic_switch/tests/unit/netmiko/test_dell.py
@@ -14,8 +14,6 @@
 
 from unittest import mock
 
-from neutron.plugins.ml2 import driver_context
-
 from networking_generic_switch.devices.netmiko_devices import dell
 from networking_generic_switch import exceptions as exc
 from networking_generic_switch.tests.unit.netmiko import test_netmiko_base
@@ -272,43 +270,6 @@ class TestNetmikoDellOS10(test_netmiko_base.NetmikoSwitchTestBase):
                          ['interface 3333',
                           'no switchport trunk allowed vlan 33',
                           'exit'])
-
-    def test_get_trunk_port_cmds_no_vlan_translation(self):
-        mock_context = mock.create_autospec(driver_context.PortContext)
-        self.switch.ngs_config['vlan_translation_supported'] = True
-        trunk_details = {'trunk_id': 'aaa-bbb-ccc-ddd',
-                         'sub_ports': [{'segmentation_id': 130,
-                                        'port_id': 'aaa-bbb-ccc-ddd',
-                                        'segmentation_type': 'vlan',
-                                        'mac_address': u'fa:16:3e:1c:c2:7e'}]}
-        mock_context.current = {'binding:profile':
-                                {'local_link_information':
-                                    [
-                                        {
-                                            'switch_info': 'foo',
-                                            'port_id': '2222'
-                                        }
-                                    ]
-                                 },
-                                'binding:vnic_type': 'baremetal',
-                                'id': 'aaaa-bbbb-cccc',
-                                'trunk_details': trunk_details}
-        mock_context.network = mock.Mock()
-        mock_context.network.current = {'provider:segmentation_id': 123}
-        mock_context.segments_to_bind = [
-            {
-                'segmentation_id': 777,
-                'id': 123
-            }
-        ]
-        res = self.switch.get_trunk_port_cmds_no_vlan_translation(
-            '2222', 777, trunk_details)
-        self.assertEqual(['interface 2222', 'switchport mode access',
-                          'switchport mode trunk',
-                          'switchport access vlan 777',
-                          'interface 2222',
-                          'switchport trunk allowed vlan 130'],
-                         res)
 
 
 class TestNetmikoDellPowerConnect(test_netmiko_base.NetmikoSwitchTestBase):

--- a/networking_generic_switch/tests/unit/test_devices.py
+++ b/networking_generic_switch/tests/unit/test_devices.py
@@ -267,11 +267,3 @@ class TestDeviceManager(unittest.TestCase):
             "ciphers": ["blowfish-cbc", "3des-cbc"],
         }
         self.assertEqual(expected, algos)
-
-    def test_driver_load_config_override(self):
-        device_cfg = {"device_type": 'netmiko_ovs_linux',
-                      "vlan_translation_supported": True}
-        device = devices.device_manager(device_cfg)
-        self.assertIsInstance(device, devices.GenericSwitchDevice)
-        self.assertNotIn('vlan_translation_support', device.config)
-        self.assertTrue(device.ngs_config['vlan_translation_supported'])

--- a/networking_generic_switch/tests/unit/test_generic_switch_mech.py
+++ b/networking_generic_switch/tests/unit/test_generic_switch_mech.py
@@ -523,65 +523,11 @@ class TestGenericSwitchDriver(unittest.TestCase):
                                      resources.PORT,
                                      'GENERICSWITCH')
 
-    @mock.patch.object(gsm.GenericSwitchDriver,
-                       '_is_vlan_translation_required', return_value=False,
-                       autospec=True)
-    @mock.patch.object(provisioning_blocks, 'provisioning_complete',
-                       autospec=True)
-    def test_update_port_postcommit_complete_provisioning_trunk(self,
-                                                                m_apc,
-                                                                m_list,
-                                                                m_vlan):
-        driver = gsm.GenericSwitchDriver()
-        driver.initialize()
-        mock_context = mock.create_autospec(driver_context.PortContext)
-        mock_context._plugin_context = mock.MagicMock()
-        trunk_details = {'trunk_id': 'aaa-bbb-ccc-ddd',
-                         'sub_ports': [{'segmentation_id': 130,
-                                        'port_id': 'aaa-bbb-ccc-ddd',
-                                        'segmentation_type': 'vlan',
-                                        'mac_address': u'fa:16:3e:1c:c2:7e'}]}
-        mock_context.network.current = {
-            'provider:physical_network': 'physnet1'
-        }
-        mock_context.current = {'binding:profile':
-                                {'local_link_information':
-                                    [
-                                        {
-                                            'switch_info': 'foo',
-                                            'port_id': '2222'
-                                        }
-                                    ]
-                                 },
-                                'binding:vnic_type': 'baremetal',
-                                'id': 'aaaa-bbbb-cccc',
-                                'binding:vif_type': 'other',
-                                'status': 'DOWN',
-                                'trunk_details': trunk_details}
-        mock_context.original = {'binding:profile': {},
-                                 'binding:vnic_type': 'baremetal',
-                                 'id': '123',
-                                 'binding:vif_type': 'unbound'}
-        mock_context.top_bound_segment = {'segmentation_id': 777,
-                                          'physical_network': 'physnet1',
-                                          'network_id': 'aaaa-bbbb-ccc'}
-        driver.update_port_postcommit(mock_context)
-        self.switch_mock.plug_port_to_network_trunk.assert_called_once_with(
-            '2222', 777, trunk_details, False)
-        m_apc.assert_called_once_with(mock_context._plugin_context,
-                                      mock_context.current['id'],
-                                      resources.PORT,
-                                      'GENERICSWITCH')
-
-    @mock.patch.object(gsm.GenericSwitchDriver,
-                       '_is_vlan_translation_required', return_value=False,
-                       autospec=True)
     @mock.patch.object(provisioning_blocks, 'provisioning_complete',
                        autospec=True)
     def test_update_portgroup_postcommit_complete_provisioning(self,
                                                                m_pc,
-                                                               m_list,
-                                                               m_ivtr):
+                                                               m_list):
         driver = gsm.GenericSwitchDriver()
         driver.initialize()
         mock_context = mock.create_autospec(driver_context.PortContext)
@@ -937,55 +883,6 @@ class TestGenericSwitchDriver(unittest.TestCase):
                                       resources.PORT,
                                       'GENERICSWITCH')
         self.switch_mock.plug_port_to_network.assert_not_called()
-
-    @mock.patch.object(gsm.GenericSwitchDriver,
-                       '_is_vlan_translation_required', return_value=False,
-                       autospec=True)
-    @mock.patch.object(provisioning_blocks, 'add_provisioning_component',
-                       autospec=True)
-    def test_bind_port_trunk(self, m_apc, m_list, m_vlan):
-        driver = gsm.GenericSwitchDriver()
-        driver.initialize()
-        mock_context = mock.create_autospec(driver_context.PortContext)
-        mock_context._plugin_context = mock.MagicMock()
-        trunk_details = {'trunk_id': 'aaa-bbb-ccc-ddd',
-                         'sub_ports': [{'segmentation_id': 130,
-                                        'port_id': 'aaa-bbb-ccc-ddd',
-                                        'segmentation_type': 'vlan',
-                                        'mac_address': u'fa:16:3e:1c:c2:7e'}]}
-        mock_context.network.current = {
-            'provider:physical_network': 'physnet1'
-        }
-        mock_context.current = {'binding:profile':
-                                {'local_link_information':
-                                    [
-                                        {
-                                            'switch_info': 'foo',
-                                            'port_id': '2222'
-                                        }
-                                    ]
-                                 },
-                                'binding:vnic_type': 'baremetal',
-                                'id': 'aaaa-bbbb-cccc',
-                                'trunk_details': trunk_details}
-        mock_context.network = mock.Mock()
-        mock_context.network.current = {
-            'provider:physical_network': 'physnet1'
-        }
-        mock_context.segments_to_bind = [
-            {
-                'segmentation_id': 777,
-                'id': 123
-            }
-        ]
-
-        driver.bind_port(mock_context)
-        mock_context.set_binding.assert_called_with(123, 'other', {})
-        m_apc.assert_called_once_with(mock_context._plugin_context,
-                                      mock_context.current['id'],
-                                      resources.PORT,
-                                      'GENERICSWITCH')
-        self.switch_mock.plug_port_to_network_trunk.assert_not_called()
 
     @mock.patch.object(provisioning_blocks, 'add_provisioning_component',
                        autospec=True)


### PR DESCRIPTION
This reverts old implementations of trunking support, which will be replaced by the new upstream implementation.