### PR TITLE
Add minimal Dell SONiC driver

### DIFF
--- a/networking_generic_switch/devices/netmiko_devices/fake.py
+++ b/networking_generic_switch/devices/netmiko_devices/fake.py
@@ -44,7 +44,7 @@ class FakeConnection(object):
         if self.device.ngs_config.get('ngs_fake_failure_prob'):
             failure_prob = self.device.ngs_config['ngs_fake_failure_prob']
             if random.random() < float(failure_prob):
-                raise Exception("Random failure!")
+                raise Exception("Random failure!")  # noqa
 
         for cmd in config_commands:
             LOG.info("%s", cmd)

--- a/networking_generic_switch/devices/netmiko_devices/sonic.py
+++ b/networking_generic_switch/devices/netmiko_devices/sonic.py
@@ -84,3 +84,27 @@ class Sonic(netmiko_devices.NetmikoSwitch):
         return net_connect.send_config_set(config_commands=cmd_set,
                                            cmd_verify=False,
                                            exit_config_mode=False)
+
+
+class DellEnterpriseSonic(Sonic):
+    """Netmiko device driver for Dell Enterprise switches.
+
+       Developed against SONiC-OS-4.2.3-Edge_Standard.
+
+       This driver must be used with the switch set to
+       standard or standard-extended naming mode. Do
+       not use the default setting of native.
+    """
+
+    def send_config_set(self, net_connect, cmd_set):
+        # Netmiko tries to use 'sudo -s' to open a root shell
+        # which doesn't work. It fails with:
+        # FATAL: root cannot launch CLI
+        net_connect.config_mode(config_command='sudo -i')
+
+        # Don't exit configuration mode, as config save requires
+        # root permissions.
+        # Verify commands have run before moving on
+        return net_connect.send_config_set(config_commands=cmd_set,
+                                           cmd_verify=True,
+                                           exit_config_mode=False)

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,6 +51,7 @@ generic_switch.devices =
     netmiko_cumulus_nvue = networking_generic_switch.devices.netmiko_devices.cumulus:CumulusNVUE
     netmiko_sonic = networking_generic_switch.devices.netmiko_devices.sonic:Sonic
     netmiko_supermicro_smis = networking_generic_switch.devices.netmiko_devices.smc:SupermicroSmis
+    netmiko_dell_enterprise_sonic = networking_generic_switch.devices.netmiko_devices.sonic:DellEnterpriseSonic
     netmiko_nokia_srl = networking_generic_switch.devices.netmiko_devices.nokia:NokiaSRL
     netmiko_pluribus = networking_generic_switch.devices.netmiko_devices.pluribus:Pluribus
     netmiko_aruba_os = networking_generic_switch.devices.netmiko_devices.aruba:ArubaOSCX


### PR DESCRIPTION
A Dell SONiC driver has been added upstream:
https://review.opendev.org/c/openstack/networking-generic-switch/+/955252

This change adds a minimal Dell SONiC driver downstream. This is essentially the existing SONiC driver, but with a slightly different enable mode command.

The change to the enable mode may not be required by the time we end up using the upstream driver. This is because the upstream driver has been developed against SONiC 4.5 which is more recent than the version used to develop this patch.

This driver requires the switch to be configured to use the standard or standard-extended naming mode.

Change-Id: Id263aa2757152012afdd6facb9f5fcd78fcc7ad8